### PR TITLE
CF-109 Add ability to differentiate between court types

### DIFF
--- a/app/assets/stylesheets/admin/forms.css.scss
+++ b/app/assets/stylesheets/admin/forms.css.scss
@@ -57,7 +57,7 @@ div.input.integer {
   }
 }
 
-div.court_areas_of_law {
+div.court_areas_of_law, div.court_court_types {
   label { width:50%; display:inline-block; }
   input { margin-right:3px; }
 }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,6 +153,10 @@ ActiveRecord::Schema.define(:version => 20130912143658) do
     t.boolean  "display"
     t.boolean  "gmaps"
     t.string   "alert"
+    t.text     "info_leaflet"
+    t.text     "defence_leaflet"
+    t.text     "prosecution_leaflet"
+    t.text     "juror_leaflet"
   end
 
   add_index "courts", ["slug"], :name => "index_courts_on_slug"

--- a/lib/tasks/import_courts.rake
+++ b/lib/tasks/import_courts.rake
@@ -281,27 +281,43 @@ namespace :import do
   
   desc "Import court types"
   task :court_types => :environment do
+    puts "Deleting existing Court types records"
+    CourtType.destroy_all
+
     puts "Importing court types"
 
     require 'csv'
 
     csv_file = File.read('db/data/court_type.csv')
-
     csv = CSV.parse(csv_file, :headers => true)
+
+    #These are the old ids for comnbined court types:
+    combined_old_ids = [2,17,19,20,22,23,25,26]
+    #2 - Combined Crown and County Court 
+    #17 - Crown and County Court
+    #19 - Family Proceedings Court, County Court, High Court 
+    #20 - Family Proceedings Court, County Court
+    #22 - County and Magistrates' Court
+    #23 - County Court and the Crown Court sitting at Warrington
+    #25 - County Court and District Registry
+    #26 - Combined Crown, County and Magistrate's Court
     
     csv.each do |row|
-      type = CourtType.new
+      unless combined_old_ids.include? row[0].to_i
+        type = CourtType.new
 
-      puts "Adding '#{row[1]}'"
+        puts "Adding '#{row[1]}'"
 
-      type.old_id = row[0]
-      type.old_description = row[1]
-      type.name = row[1]
-      type.old_ids_split = row[2]
+        type.old_id = row[0]
+        type.old_description = row[1]
+        type.name = row[1]
+        type.old_ids_split = row[2]
 
-      type.save!
+        type.save!
+      end
     end
-
+    puts "Adding 'Tribunal'"
+    CourtType.create!(:name => "Tribunal")
   end
   
   desc "Import areas of law"

--- a/lib/tasks/process_courts.rake
+++ b/lib/tasks/process_courts.rake
@@ -1,33 +1,48 @@
 namespace :process do
 
-  desc "Create links between courts and court types"
+  desc "Create links between courts and court types"  
   task :court_types => :environment do
-
+    combined_court_types = [
+      {:old_id => 2, :name => "Combined  Crown and County Court", :old_ids_split => "3,4"},
+      {:old_id => 17, :name => "Crown and County Court", :old_ids_split => "3,4"},
+      {:old_id => 19, :name => "Family Proceedings Court, County Court, High Court", :old_ids_split => "3,5,16"},
+      {:old_id => 20, :name => "Family Proceedings Court, County Court", :old_ids_split => "3,16"},
+      {:old_id => 22, :name => "County and Magistrates' Court", :old_ids_split => "3,6"},
+      {:old_id => 23, :name => "County Court and the Crown Court sitting at Warrington", :old_ids_split => "3,4"},
+      {:old_id => 25, :name => "County Court and District Registry", :old_ids_split => "3"},
+      {:old_id => 26, :name => "Combined Crown, County and Magistrate's Court", :old_ids_split => "3,4,6"}
+    ]
+    puts "Deleting existing CourtTypesCourt records"
+    CourtTypesCourt.destroy_all
     Court.all.each do |court|
-
-      court_type = CourtType.find_by_old_id(court.old_court_type_id)
-
-      # Make an array of court types
-      if court_type.old_ids_split.present?
-        court_types = court_type.old_ids_split.split(',')
-      else
-        court_types = [court_type.old_id]
+      if court.old_court_type_id && (court_type = CourtType.find_by_old_id(court.old_court_type_id))
+        # Make an array of court types
+        if court_type.old_ids_split.present?
+          court_types = court_type.old_ids_split.split(',')
+        else
+          court_types = [court_type.old_id]
+        end
+      else          
+        combined_court_types.each do |cct|
+          if court.old_court_type_id == cct[:old_id]
+            court_types = cct[:old_ids_split].split(',')
+          end
+        end                    
       end
 
-      court_types.each do |old_id|
-        
-        type = CourtType.find_by_old_id(old_id)
-
-        court_type = CourtTypesCourt.new
-        court_type.court_id = court.id
-        court_type.court_type_id = type.id
-
-        court_type.save!
-        puts "Added court type #{type.name} for #{court.name}"
+      if court_types
+        court_types.each do |old_id|            
+          type = CourtType.find_by_old_id(old_id)
+          court_type_court = CourtTypesCourt.create!(:court_id => court.id, :court_type_id => type.id)
+          puts "Added court type #{type.name} for #{court.name}"
+        end
       end
 
+      if court.name.downcase.include? "tribunal"
+        type = CourtType.find_by_name("Tribunal")
+        court_type_court = CourtTypesCourt.create!(:court_id => court.id, :court_type_id => type.id)
+        puts "Added court type #{type.name} for #{court.name}"        
+      end
     end
-
   end
-
 end


### PR DESCRIPTION
Squashed the following commits into one:
Fix rake tasks for importing and processing court types. Add court type field to admin edit page.
CF-113 Replace 'Update court' button with 'Update'
Fix court type processing rake task. Add court type on court edit page.
Temporarily remove court type field from edit page for server data processing.
fix merge issues

If the code is ok, I'd like to try running the rake tasks import:court_types and process:court_types on staging. Then I can expose the court type field in the admin view. If staging works, do the same for production.
