### PR TITLE
CF-5 added link to gmaps in a meta element

### DIFF
--- a/app/views/courts/_court_details.html.haml
+++ b/app/views/courts/_court_details.html.haml
@@ -124,7 +124,7 @@
 -# === Map ===
 - if @court.locatable?
   %h2#location Location of the building:
-
+  %meta{:property => "map", :content => "http://maps.google.com/maps?q=loc:#{@court.latitude}+#{@court.longitude}" }
   %form#directions.hidden-print{:action => "http://maps.google.com/maps", :method => "get", :rel => "ext"}
     %label{:for => "saddr"} Enter your location
     %input{:name => "saddr", :type => "text", :value => params[:from]}


### PR DESCRIPTION
google needs to see a link to gmaps in order to locate the place and show the map in google search results. We don't need that link to be visible on the page, so we put it in a meta element.
