### PR TITLE
CF-109, CF-112, CF-63, CF-65 Differentiate between court types and show corresponding leaflets

### DIFF
--- a/app/assets/stylesheets/admin/forms.css.scss
+++ b/app/assets/stylesheets/admin/forms.css.scss
@@ -151,6 +151,13 @@ form {
 }
 
 // Display features for high level admin users only
+textarea.admin-only,
 .admin-only input {
   background: #eee;
+}
+
+textarea.leaflet {
+  width: 568px;
+  height: 100px;
+  resize: none;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,8 @@ section#content {
 article .inner {
   padding:0;
 }
+
+.char-limit {
+  font-size: 10px;
+  color: #444444;
+}

--- a/app/assets/stylesheets/feedbacks.scss
+++ b/app/assets/stylesheets/feedbacks.scss
@@ -7,8 +7,4 @@ form.new_feedback {
   label.radio {
     padding-right: 10px;
   }
-  #char-limit {
-    font-size: 10px;
-    color: #444444;
-  }
 }

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -39,6 +39,16 @@ class CourtsController < ApplicationController
     end
   end
   
+  def juror
+    @court = Court.find(params[:id])
+
+    if request.path != juror_path(@court, :format => params[:format])
+      redirect_to juror_path(@court, :format => params[:format]), status: :moved_permanently
+    else
+      respond_with @court
+    end
+  end
+
   def show
     @court = Court.find(params[:id])
 

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -9,7 +9,9 @@ class Court < ActiveRecord::Base
   has_many :court_types, :through => :court_types_courts
   has_many :courts_areas_of_law
   has_many :areas_of_law, :through => :courts_areas_of_law
-  attr_accessible :court_number, :info, :name, :slug, :area_id, :cci_identifier, :cci_code, :old_id, :old_court_type_id, :area, :addresses_attributes, :latitude, :longitude, :court_type_ids, :area_of_law_ids, :opening_times_attributes, :contacts_attributes, :emails_attributes, :court_facilities_attributes, :image, :image_file, :remove_image_file, :display, :alert
+  attr_accessible :court_number, :info, :name, :slug, :area_id, :cci_identifier, :cci_code, :old_id, :old_court_type_id, :area, :addresses_attributes, :latitude, :longitude, :court_type_ids, :area_of_law_ids, :opening_times_attributes, :contacts_attributes, :emails_attributes, :court_facilities_attributes, :image, :image_file, :remove_image_file, :display, :alert,
+                  :info_leaflet, :defence_leaflet, :prosecution_leaflet, :juror_leaflet
+
   accepts_nested_attributes_for :addresses, allow_destroy: true
   accepts_nested_attributes_for :opening_times, allow_destroy: true
   accepts_nested_attributes_for :contacts, allow_destroy: true
@@ -94,4 +96,16 @@ class Court < ActiveRecord::Base
     end
   end
 
+  def leaflets
+    @leaflets || begin
+      @leaflets = []
+      if self.court_types.empty? || self.court_types.pluck(:name).any? {|ct| ct != "Family Proceedings Court" && ct != "County Court" && ct != "Tribunal"}
+        @leaflets.push("defence", "prosecution")
+      end
+      if self.court_types.pluck(:name).any? {|ct| ct == "Crown Court"}
+        @leaflets << "juror"
+      end
+      @leaflets
+    end
+  end
 end

--- a/app/views/admin/courts/_form.html.erb
+++ b/app/views/admin/courts/_form.html.erb
@@ -26,6 +26,9 @@
   <%= f.input :cci_code %>
   <%= f.association :area, :hint => 'Used on <a href="/regions" rel="help">Browse regions</a>' %>
 
+  <h2>Court types</h2>
+  <%= f.association :court_types, :collection => CourtType.all, :as => :check_boxes, :label => false %>
+
   <h2>Urgent notice</h2>
   <p>Use this field to display a temporary notice of building closure. This is limited to 250 characters including spaces.</p>
   <%= f.input :alert, :maxlength => 250, :hint => 'Remove all text to hide the alert' %>
@@ -104,13 +107,37 @@
   <p>Please only add concise details about this particular court, no contact details or guidance on going to court.</p>
   <%= f.input :info, :input_html => { :class => 'ckeditor' } %>
 
+  <% if current_user.admin %>
+    <h2>Information leaflet updates</h2>
+    <p>Please add details that you wish to appear only for this court or tribunal and only on the information leaflet.</p>
+    <div>
+      <%= f.text_area :info_leaflet, :class => 'admin-only leaflet' %>
+      <small class="char-limit">2,500 characters max</small>
+    </div>
+
+    <% if @court.leaflets.include? "defence" %>
+      <h2>Defence witness leaflet updates</h2>
+      <p>Please add details that you wish to appear only for this court or tribunal and only on the defence witness leaflet.</p>
+      <div>
+        <%= f.text_area :defence_leaflet, :class => 'admin-only leaflet' %>
+        <small class="char-limit">2,500 characters max</small>
+      </div>
+    <% end %>
+
+    <% if @court.leaflets.include? "prosecution" %>
+      <h2>Prosecution witness leaflet updates</h2>
+      <p>Please add details that you wish to appear only for this court or tribunal and only on the prosecution witness leaflet.</p>
+      <div>
+        <%= f.text_area :prosecution_leaflet, :class => 'admin-only leaflet' %>
+        <small class="char-limit">2,500 characters max</small>
+      </div>
+    <% end %>
+  <% end %>
+
   <fieldset class="court-closed">
     <p>Un-check this box if this court or tribunal is no longer in service. Use this rather than deleting it, so that the web page still exists but informs the public the court or tribunal is now closed.</p>
     <%= f.input :display %>
   </fieldset>
-
-  <!-- Decomissioned fields -->
-  <%#= f.association :court_types %>
 
   <div class="form-actions">
     <%= f.submit "Update", :class => "button" %>

--- a/app/views/admin/courts/edit.html.erb
+++ b/app/views/admin/courts/edit.html.erb
@@ -1,3 +1,21 @@
 <%= content_for :title, 'Editing court or tribunal' %>
 
+<% content_for :scripts do %>
+  <script>
+  $('textarea.leaflet').keyup(function(){
+    var charlimit = 2500,
+        notice = $(this).siblings('.char-limit');
+    
+    if($(this).val().length > charlimit) {
+      $(this)
+        .val($(this).val().substr(0, charlimit))
+        .css('outline', 'solid 3px #ff0000');
+      notice.css('color', '#ff0000')
+    } else {
+      $(this).add(notice).removeAttr('style');
+    }
+  });
+  </script>
+<% end %>
+
 <%= render 'form' %>

--- a/app/views/courts/_court_details.html.haml
+++ b/app/views/courts/_court_details.html.haml
@@ -109,17 +109,9 @@
       - if court_facility.description.present?
         %dd= court_facility.description.html_safe
 
-
-
 - unless print_view
   -# === Print links ===
-  %h2.icon-print.hidden-print Information leaflets (ready to print):
-  %ul.unstyled.hidden-print
-    %li= link_to 'Local information leaflet', information_path(@court)
-    %li= link_to 'Defence witness leaflet', defence_path(@court)
-    %li= link_to 'Prosecution witness leaflet', prosecution_path(@court)
-
-
+  = render 'court_leaflets'
 
 -# === Map ===
 - if @court.locatable?

--- a/app/views/courts/_court_leaflets.html.haml
+++ b/app/views/courts/_court_leaflets.html.haml
@@ -1,0 +1,9 @@
+%h2.icon-print.hidden-print Information leaflets (ready to print):
+%ul.unstyled.hidden-print
+  %li= link_to 'Local information leaflet', information_path(@court)
+  - if @court.leaflets.include? "defence"
+    %li= link_to 'Defence witness leaflet', defence_path(@court)
+  - if @court.leaflets.include? "prosecution"
+    %li= link_to 'Prosecution witness leaflet', prosecution_path(@court)
+  - if @court.leaflets.include? "juror"
+    %li= link_to 'Juror leaflet', juror_path(@court)

--- a/app/views/courts/defence.html.haml
+++ b/app/views/courts/defence.html.haml
@@ -18,77 +18,125 @@
   
   ## Introduction
 
-  You may be a witness or a parent of a child witness who has been asked to attend court to give evidence on behalf of the person on trial (known as the defendant) You will already have been contacted by either the defendant or the solicitor acting on their behalf.
+  You may be a witness or a parent of a child witness who has been asked to attend court to 
+  give evidence on behalf of the person on trial (known as the defendant) You will already 
+  have been contacted by either the defendant or the solicitor acting on their behalf.
 
-  The information in these pages helps you answer some of the questions you may have about going to court and will help you understand what happens at court.
+  The information in these pages helps you answer some of the questions you may have about 
+  going to court and will help you understand what happens at court.
 
 
 = render 'court_details'
 
+- if @court.defence_leaflet.present?
+  %h2 Update
+  %p
+    = @court.defence_leaflet
 
 :markdown
   
   ## Roles and Responsibilities
 
-  **The Witness Service:** The Witness Service helps witnesses and their families and friends before, during and after a court hearing.It is a national charity, which helps people cope with crime. If you come to court to give evidence a Witness Service representative will offer you support.
+  **The Witness Service:** The Witness Service helps witnesses and their families and friends 
+  before, during and after a court hearing.It is a national charity, which helps people cope 
+  with crime. If you come to court to give evidence a Witness Service representative will 
+  offer you support.
 
   
   
   ## Before you arrive
 
-  You can arrange with the Witness Service to visit the court in advance of the trial. This may make you feel more confident about attending court to give evidence. If you think this might help, please call the Witness Service using the contact details provided.
+  You can arrange with the Witness Service to visit the court in advance of the trial. This may 
+  make you feel more confident about attending court to give evidence. If you think this might 
+  help, please call the Witness Service using the contact details provided.
   
-  If you feel you need to wait away from the public area please tell the Court Usher or Witness Service representative who will try to make alternative arrangements. Family and friends attending with you may not be allowed to wait in the private waiting areas in which case they will be seated elsewhere, away from the prosecution witness wherever possible. Ask the Witness Service before attending.
+  If you feel you need to wait away from the public area please tell the Court Usher or Witness 
+  Service representative who will try to make alternative arrangements. Family and friends 
+  attending with you may not be allowed to wait in the private waiting areas in which case they 
+  will be seated elsewhere, away from the prosecution witness wherever possible. Ask the Witness 
+  Service before attending.
   
-  If you have particular needs, possibly arising out of a disability or religious observance, please let someone know in advance of the day you are due to attend by contacting the solicitor representing the defendant or by calling the Witness Service representative, please see contact details for information.
+  If you have particular needs, possibly arising out of a disability or religious observance, 
+  please let someone know in advance of the day you are due to attend by contacting the 
+  solicitor representing the defendant or by calling the Witness Service representative, please 
+  see contact details for information.
   
-  If you are a child or young witness, special arrangements for your needs will be made by the solicitor.
+  If you are a child or young witness, special arrangements for your needs will be made by the 
+  solicitor.
   
-  There are no facilities for children, who are not witnesses, to be looked after at court so avoid bringing children with you if possible.
+  There are no facilities for children, who are not witnesses, to be looked after at court so 
+  avoid bringing children with you if possible.
   
-  If you have to bring your child to court, please bring an adult friend or relative to sit with them whilst you give your evidence, as court staff are unable to help.
+  If you have to bring your child to court, please bring an adult friend or relative to sit with 
+  them whilst you give your evidence, as court staff are unable to help.
   
-  It is important to inform the solicitor, or the person asking you to come to court, if you have any difficulties attending on the date you have been given. Please ensure that you have confirmed in advance, with the solicitor or with the person that asked you to attend, that you will be attending on the date and at the time specified.
+  It is important to inform the solicitor, or the person asking you to come to court, if you 
+  have any difficulties attending on the date you have been given. Please ensure that you have 
+  confirmed in advance, with the solicitor or with the person that asked you to attend, that you 
+  will be attending on the date and at the time specified.
   
-  Please let the solicitor know, preferably in advance of the trial, if you have any commitments during the day which cannot be changed for example, children at school who need to be collected.
+  Please let the solicitor know, preferably in advance of the trial, if you have any commitments 
+  during the day which cannot be changed for example, children at school who need to be collected.
 
   
   
   ## On arrival
 
-  You should arrive at court at the time notified to you which is usually 30 minutes before the trial or the hearing is due to start. If you anticipate any difficulties with getting to court on time on the day, please notify the person asking you to attend immediately. It is important that the court knows of any possible delay otherwise it may think that you are not coming. You, as with other court users, will be required to undergo standard security checks.
+  You should arrive at court at the time notified to you which is usually 30 minutes before the 
+  trial or the hearing is due to start. If you anticipate any difficulties with getting to court 
+  on time on the day, please notify the person asking you to attend immediately. It is important 
+  that the court knows of any possible delay otherwise it may think that you are not coming. You, 
+  as with other court users, will be required to undergo standard security checks.
   
-  Unless special arrangements have been made for you, when you arrive at court go straight to the reception point, tell the receptionist your name and that you are a defence witness.
+  Unless special arrangements have been made for you, when you arrive at court go straight to the 
+  reception point, tell the receptionist your name and that you are a defence witness.
   
-  If you have asked for the support from the Witness Service, you will be introduced to their representative who will take you to a waiting area.
+  If you have asked for the support from the Witness Service, you will be introduced to their 
+  representative who will take you to a waiting area.
   
-  If you are attending alone, you will be directed to the public waiting area. The person who has asked you to attend will be informed that you have arrived and they will come and speak to you.
+  If you are attending alone, you will be directed to the public waiting area. The person who has 
+  asked you to attend will be informed that you have arrived and they will come and speak to you.
   
   
   
   ## Before you give evidence
 
-  Arrangements can be made for you to see where you will be giving evidence. Generally this is done at a pre-trial visit, although this may occasionally be possible on the day if time allows. Please ask the Court Usher or the Witness Service representative.
+  Arrangements can be made for you to see where you will be giving evidence. Generally this is done 
+  at a pre-trial visit, although this may occasionally be possible on the day if time allows. 
+  Please ask the Court Usher or the Witness Service representative.
   
-  You will give evidence in a courtroom, or in a room away from the court if special arrangements have been made for you i.e video links.
+  You will give evidence in a courtroom, or in a room away from the court if special arrangements 
+  have been made for you i.e video links.
   
-  It might be a while since you have seen the written statement that you made. You should be given the chance to see it again before you give evidence. If not, then please ask the solicitor or the person who asked you to attend. It might help to refresh your memory.
+  It might be a while since you have seen the written statement that you made. You should be given 
+  the chance to see it again before you give evidence. If not, then please ask the solicitor or the 
+  person who asked you to attend. It might help to refresh your memory.
   
-  Oath taking procedures will be explained to you and you will be asked whether you want to swear to tell the truth on the holy book of your religion or whether you wish to make an affirmation which is a non-religious way of swearing to tell the truth. If you are a witness in a Youth Court you will promise to tell the truth or affirm. You will be asked about other rituals and practices you may want to observe before giving evidence.
+  Oath taking procedures will be explained to you and you will be asked whether you want to swear to 
+  tell the truth on the holy book of your religion or whether you wish to make an affirmation which 
+  is a non-religious way of swearing to tell the truth. If you are a witness in a Youth Court you 
+  will promise to tell the truth or affirm. You will be asked about other rituals and practices you 
+  may want to observe before giving evidence.
   
-  Light refreshments may be available for you to buy. Please see the facilities section for more information. You may have access to toilets within close proximity to your waiting area.
+  Light refreshments may be available for you to buy. Please see the facilities section for more 
+  information. You may have access to toilets within close proximity to your waiting area.
   
-  We aim to call you to give your evidence within two hours of the start time, although this is not always possible.
+  We aim to call you to give your evidence within two hours of the start time, although this is not 
+  always possible.
   
-  We will provide you with regular updates on the progress of the case and explain the reasons for any delay, where possible. If you are likely to have to wait a long time, the court will consider letting you leave court to return at a later time.
+  We will provide you with regular updates on the progress of the case and explain the reasons for 
+  any delay, where possible. If you are likely to have to wait a long time, the court will consider 
+  letting you leave court to return at a later time.
 
   
   
   ## Giving your evidence
 
-  You will be accompanied, usually by a court usher or a member of the Witness Service to the courtroom, where you are going to give your evidence.
+  You will be accompanied, usually by a court usher or a member of the Witness Service to the 
+  courtroom, where you are going to give your evidence.
   
-  In the courtroom, you will be asked by the Court Usher to take the oath or affirm in accordance with the procedures already explained to you.
+  In the courtroom, you will be asked by the Court Usher to take the oath or affirm in accordance 
+  with the procedures already explained to you.
   
   If you are not required to give evidence the reason for this will be explained to you.
 
@@ -96,7 +144,9 @@
   
   ## After you have given your evidence
 
-  When you have finished giving your evidence you will be thanked and will be told whether you are allowed to leave. If you wish to stay and watch the rest of the case, this will be arranged if the Court agrees.
+  When you have finished giving your evidence you will be thanked and will be told whether you are 
+  allowed to leave. If you wish to stay and watch the rest of the case, this will be arranged if 
+  the Court agrees.
 
   
   
@@ -104,40 +154,60 @@
 
   You should be told the result of your case by the person who has asked you to come to court.
 
-  You may be able to claim the cost of having to come to court. You should ask the solicitor to make the application before you leave. If this is not done, then you must send your claim in writing to the court you attended. If you have receipts, you should send these with your claim.
+  You may be able to claim the cost of having to come to court. You should ask the solicitor to make 
+  the application before you leave. If this is not done, then you must send your claim in writing to 
+  the court you attended. If you have receipts, you should send these with your claim.
   
-  If there is an appeal against the decision of the court then it may be necessary for you to attend court again. The solicitor who called you will explain the procedure to you.
+  If there is an appeal against the decision of the court then it may be necessary for you to attend 
+  court again. The solicitor who called you will explain the procedure to you.
 
   
   
   ## Feedback and complaints
 
-  Your comments are important to us. If you wish to provide any feedback on the service you received when attending court or wish to make suggestions as to how we might improve our service, please write to the Court Manager at the Court you have attended - please see contact details for further information.
+  Your comments are important to us. If you wish to provide any feedback on the service you received 
+  when attending court or wish to make suggestions as to how we might improve our service, please 
+  write to the Court Manager at the Court you have attended - please see contact details for 
+  further information.
   
-  If you wish to make a complaint about the service you received, please ask a member of staff at the court or the Court Manager for an EX343 'Complaints leaflet', which you can fill in with the details of your complaint. If you have any comments on this leaflet you can email your comments to victim.witnessbranch@hmcts.gsi.gov.uk.
+  If you wish to make a complaint about the service you received, please ask a member of staff at the 
+  court or the Court Manager for an EX343 'Complaints leaflet', which you can fill in with the details 
+  of your complaint. If you have any comments on this leaflet you can email your comments to 
+  victim.witnessbranch@hmcts.gsi.gov.uk.
 
   
   
   ## What additional help is available for court users with a disability?
 
-  If you have a disability which makes going to court or communicating difficult, please contact a member of staff at the court. If you are deaf or hard of hearing and require assistance the following services can help you once you have obtained the relevant court telephone number: Textphone users calling voicephones or textphones dial 18001, Voicephone users calling textphones or voicephones dial 18002, Text relay service on 0870 240 5152.
+  If you have a disability which makes going to court or communicating difficult, please contact a 
+  member of staff at the court. If you are deaf or hard of hearing and require assistance the following 
+  services can help you once you have obtained the relevant court telephone number: Textphone users 
+  calling voicephones or textphones dial 18001, Voicephone users calling textphones or voicephones dial 
+  18002, Text relay service on 0870 240 5152.
 
   
   
   ## More information
 
-  Further information on going to court can be obtained from: Website: www.justice.gov.uk - visit the web page on 'Being a Witness'
+  Further information on going to court can be obtained from: Website: www.justice.gov.uk - visit the 
+  web page on 'Being a Witness'
   
-  **DVD:** 'Going to Court - A step by step guide to being witness' is available at [http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o](http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o)
+  **DVD:** 'Going to Court - A step by step guide to being witness' is available at 
+  [http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o](http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o)
 
   **Large print versions of this leaflet are available**
 
-  A generic version of this leaflet (i.e this will not include a map of the local court you have been asked to attend) is available in the following languages: English large print, Welsh, Arabic, Bengali, Cantonese, Gujarati, Hindi, Polish, Punjabi and Urdu.
+  A generic version of this leaflet (i.e this will not include a map of the local court you have 
+  been asked to attend) is available in the following languages: English large print, Welsh, Arabic, 
+  Bengali, Cantonese, Gujarati, Hindi, Polish, Punjabi and Urdu.
   
   
   
   ## Getting to the court
 
-  To plan your route to this court, please visit the Court Information and Addresses section of the Justice Website #{root_url}
+  To plan your route to this court, please visit the Court Information and Addresses section of the 
+  Justice Website #{root_url}
   
-  Choose **#{@court.name}** from the Court Name Search and select Get Court Details. On the Court Information page enter your postcode on the Route Planner on the right- hand side to get a detailed description of your journey by bus, train or car.
+  Choose **#{@court.name}** from the Court Name Search and select Get Court Details. On the Court 
+  Information page enter your postcode on the Route Planner on the right- hand side to get a detailed 
+  description of your journey by bus, train or car.

--- a/app/views/courts/information.html.haml
+++ b/app/views/courts/information.html.haml
@@ -16,15 +16,30 @@
 
 = render 'court_details'
 
+- if @court.info_leaflet.present?
+  %h2 Update
+  %p
+    = @court.info_leaflet
+
 :markdown
 
   ##  Help and advice
 
-  If you have any concerns about coming to court or the court experience please speak to a member of staff. Court staff can advise you on procedures, give you the forms you need and help you fill them in. They cannot however give you legal advice. You may be able to get free legal advice from a law centre, a Citizens Advice Bureau or consumer advice centre or alternatively you can contact the Legal Aid Agency, www.gov.uk/legal-aid. County Courts only: If you want to settle your dispute without going to court, find a civil mediation provider at www.civilmediation.justice.gov.uk/.
+  If you have any concerns about coming to court or the court experience please speak 
+  to a member of staff. Court staff can advise you on procedures, give you the 
+  forms you need and help you fill them in. They cannot however give you legal advice. 
+  You may be able to get free legal advice from a law centre, a Citizens Advice 
+  Bureau or consumer advice centre or alternatively you can contact the Legal 
+  Aid Agency, www.gov.uk/legal-aid. County Courts only: If you want to settle your 
+  dispute without going to court, find a civil mediation provider at 
+  www.civilmediation.justice.gov.uk/.
 
   ## What additional help is available for court users with a disability?
 
-  If you have a disability which makes going to court or communicating difficult, please contact a member of staff at the court. If you are deaf or hard of hearing and require assistance the following services can help you once you have obtained the relevant court telephone number:
+  If you have a disability which makes going to court or communicating difficult, please 
+  contact a member of staff at the court. If you are deaf or hard of hearing and require 
+  assistance the following services can help you once you have obtained the relevant court 
+  telephone number:
 
   * Textphone users calling voicephones or textphones - dial 18001
   * Voicephone users calling textphones or voicephones - dial 18002
@@ -32,4 +47,11 @@
 
   ## Personal belongings
 
-  Court staff cannot look after your personal belongings and cannot be held responsible for their safety. Do not leave bags unattended. Please also note that court users are not permitted to use recording equipment, photography, mobile telephones and pagers in courtrooms. Security at court is of paramount importance to HMCTS and we work to ensure that all visitors to court, including victims and witnesses are in a safe and secure environment. Sharp objects such as knives are not allowed in the court building and if brought to court they will be removed by security and will not be returned when you leave. If carrying a kirpan this must be concealed and the overall length must not exceed 6 inches, (2 inches handle, 4 inches blade).
+  Court staff cannot look after your personal belongings and cannot be held responsible for 
+  their safety. Do not leave bags unattended. Please also note that court users are not permitted 
+  to use recording equipment, photography, mobile telephones and pagers in courtrooms. Security at 
+  court is of paramount importance to HMCTS and we work to ensure that all visitors to court, 
+  including victims and witnesses are in a safe and secure environment. Sharp objects such as knives 
+  are not allowed in the court building and if brought to court they will be removed by security 
+  and will not be returned when you leave. If carrying a kirpan this must be concealed and the 
+  overall length must not exceed 6 inches, (2 inches handle, 4 inches blade).

--- a/app/views/courts/juror.html.haml
+++ b/app/views/courts/juror.html.haml
@@ -1,0 +1,50 @@
+- content_for :title, "Local information for Jurors"
+- content_for :last_updated, @court.updated_at.to_s(:standard)
+- content_for :nav do
+  %li
+    = link_to 'Courts', courts_path
+  %li
+    = link_to @court.name, @court
+
+%p.hidden-print.well
+  = link_to 'Print this page', '#', :class => 'print-link'
+  to take these details with you.
+
+
+:markdown
+
+  ## Contacting the court
+
+  Before you start your jury service: For any queries about your jury service in 
+  the week before you are due to attend, please contact the court directly and not 
+  the Jury Central Summoning Bureau. Please contact the jury team at the court.
+
+  When you are on jury service: If you become ill, please telephone the court for 
+  advice. Do not obtain a medical certificate unless the court asks for one. If 
+  someone needs to contact you urgently, a message may be left on the above number.
+
+
+  ## Attendance at court
+  
+  For information on when to arrive, please refer to the time on your confirmation 
+  letter. For subsequent days, you will be told when to arrive at court. The court 
+  normally sits from 10.00am to 4.30pm each day. However, depending on the way the 
+  trial progresses, the judge may ask you to sit longer or shorter hours on a daily 
+  basis. You will be notified by court staff about timings for lunch.
+  
+
+  ## Important information whilst at court
+
+  In the unlikely event of an emergency, court staff may ask you to provide a contact 
+  name and number of a family member or friend.
+
+  Please do not bring:
+
+  * The use of cameras or recording equipment is prohibited within all court buildings. 
+  Mobile phones with features such as cameras or recording equipment are permitted, but 
+  the additional features must not be used in the court building.
+
+  * Sharp objects such as knives are not allowed in the court building and if brought 
+  to court they will be removed by security and will not be returned when you leave. 
+  If carrying a kirpan this must be concealed and the overall length must not exceed 6 
+  inches, (2 inches handle, 4 inches blade).

--- a/app/views/courts/prosecution.html.haml
+++ b/app/views/courts/prosecution.html.haml
@@ -12,113 +12,191 @@
 
 
 :markdown
-  You have been asked to attend court as a prosecution witness. This information will help you.
+  You have been asked to attend court as a prosecution witness. This information 
+  will help you.
 
   ##  Introduction
 
-  You may be a witness, victim or a parent of a child witness/victim. The following information in these pages will help answer some of the questions you may have about going to court and will help you understand what happens at court.
+  You may be a witness, victim or a parent of a child witness/victim. The following 
+  information in these pages will help answer some of the questions you may have 
+  about going to court and will help you understand what happens at court.
 
 = render 'court_details'
+
+- if @court.prosecution_leaflet.present?
+  %h2 Update
+  %p
+    = @court.prosecution_leaflet
 
 :markdown
 
   ##  Roles and Responsibilities
 
-  **The Witness Care Unit:** The Witness Care Unit is part of the joint Police and Crown Prosecution team and is responsible for providing you, with support, information on the progress of your case and making the arrangements for you to attend Court. The Witness Care Unit should be your first point of contact.
+  **The Witness Care Unit:** The Witness Care Unit is part of the joint Police and 
+  Crown Prosecution team and is responsible for providing you, with support, information 
+  on the progress of your case and making the arrangements for you to attend Court. 
+  The Witness Care Unit should be your first point of contact.
 
-  **The Witness Service:** The Witness Service helps witnesses and victims, their families and friends before, during and after a court hearing. It is a national charity, which helps people cope with crime. If you come to court to give evidence a Witness Service representative will offer you support.
+  **The Witness Service:** The Witness Service helps witnesses and victims, their families 
+  and friends before, during and after a court hearing. It is a national charity, which 
+  helps people cope with crime. If you come to court to give evidence a Witness Service 
+  representative will offer you support.
 
   ##  Before you arrive
 
-  You can arrange with the Witness Service or Witness Care Unit to visit the Court in advance of the trial.
-  This may make you feel more confident about attending Court to give evidence. If you think this might help, please call the Witness Service or the Witness Care Unit using the contact details provided.
+  You can arrange with the Witness Service or Witness Care Unit to visit the Court in advance 
+  of the trial.
+  This may make you feel more confident about attending Court to give evidence. If you think 
+  this might help, please call the Witness Service or the Witness Care Unit using the contact 
+  details provided.
 
-  If you feel you need to wait away from the public area please tell the Court Usher or Witness Service representative who will try to make alternative arrangements. Family and friends attending with you may not be allowed to wait in the witness waiting areas, in which case they will be seated elsewhere away from the defendant wherever possible. Ask the Witness Service before attending
+  If you feel you need to wait away from the public area please tell the Court Usher or 
+  Witness Service representative who will try to make alternative arrangements. Family and 
+  friends attending with you may not be allowed to wait in the witness waiting areas, in which 
+  case they will be seated elsewhere away from the defendant wherever possible. Ask the Witness 
+  Service before attending
 
-  If you have particular needs, possibly arising out of a disability or religious observance, please let someone know in advance of the day you are due to attend by contacting the Witness Care Unit or by calling the Witness Service - please see contact details for information.
+  If you have particular needs, possibly arising out of a disability or religious observance, 
+  please let someone know in advance of the day you are due to attend by contacting the Witness 
+  Care Unit or by calling the Witness Service - please see contact details for information.
 
-  If you are a child or young witness, special arrangements for your needs will be made by the Witness Care Unit.
+  If you are a child or young witness, special arrangements for your needs will be made by the 
+  Witness Care Unit.
 
-  There are no facilities for children, who are not witnesses, to be looked after at court so avoid bringing children with you if possible. If you wish to discuss alternative care arrangements please contact the Witness Care Unit.
+  There are no facilities for children, who are not witnesses, to be looked after at court so 
+  avoid bringing children with you if possible. If you wish to discuss alternative care 
+  arrangements please contact the Witness Care Unit.
 
-  If you have to bring your child to court, please bring an adult friend or relative to sit with them whilst you give your evidence, as Court staff are unable to help.
+  If you have to bring your child to court, please bring an adult friend or relative to sit with 
+  them whilst you give your evidence, as Court staff are unable to help.
 
-  It is important to inform the Witness Care Unit if you have any difficulties attending on the date you have been asked to attend. Please ensure that you have confirmed in advance with the Witness Care Unit that you will be attending on the date and at the time specified.
+  It is important to inform the Witness Care Unit if you have any difficulties attending on the 
+  date you have been asked to attend. Please ensure that you have confirmed in advance with the 
+  Witness Care Unit that you will be attending on the date and at the time specified.
 
-  Please let the Witness Care Unit, know preferably in advance of the trial if you have any commitments during the day which cannot be changed, for example, children at school who need to be collected.
+  Please let the Witness Care Unit, know preferably in advance of the trial if you have any 
+  commitments during the day which cannot be changed, for example, children at school who need 
+  to be collected.
 
   ##  On arrival
 
-  You should arrive at Court at the time notified to you by the Witness Care Unit which is usually 30 minutes before the trial or hearing is due to start. If you anticipate any difficulties with getting to the court on time on the day, please notify the Witness Care Unit immediately. It is important that the Court knows of any possible delay otherwise it may think that you are not coming.
+  You should arrive at Court at the time notified to you by the Witness Care Unit which is 
+  usually 30 minutes before the trial or hearing is due to start. If you anticipate any 
+  difficulties with getting to the court on time on the day, please notify the Witness Care Unit 
+  immediately. It is important that the Court knows of any possible delay otherwise it may think 
+  that you are not coming.
 
   You, as with other court users, will be required to undergo standard security checks.
 
-  Unless special arrangements have been made for you, when you arrive at court please go straight to the reception point, tell the receptionist your name and that you are a prosecution witness.
+  Unless special arrangements have been made for you, when you arrive at court please go straight 
+  to the reception point, tell the receptionist your name and that you are a prosecution witness.
 
-  If you have asked for support from the Witness Service, you will be introduced to their representative who will take you to a waiting area.
+  If you have asked for support from the Witness Service, you will be introduced to their 
+  representative who will take you to a waiting area.
 
   ##  Before you give evidence
 
-  Arrangements can be made for you to see where you will be giving evidence. Generally this is done at a pre-trial visit, although this may occasionally be possible on the day. Please ask the Court Usher or the Witness Service representative.
+  Arrangements can be made for you to see where you will be giving evidence. Generally this is 
+  done at a pre-trial visit, although this may occasionally be possible on the day. Please ask 
+  the Court Usher or the Witness Service representative.
 
-  You will give evidence in a courtroom, or in a room away from the court if special arrangements have been made for you i.e video links.
+  You will give evidence in a courtroom, or in a room away from the court if special arrangements 
+  have been made for you i.e video links.
 
-  It might be a while since you have seen the written or video statement which you made to the police. You should be given the chance to see it again before you give evidence. If not, then please ask the Crown Prosecution Service representative at court. It might help to refresh your memory.
+  It might be a while since you have seen the written or video statement which you made to the 
+  police. You should be given the chance to see it again before you give evidence. If not, then 
+  please ask the Crown Prosecution Service representative at court. It might help to refresh your 
+  memory.
 
-  Oath taking procedures will be explained to you and you will be asked whether you want to swear to tell the truth on the holy book of your religion or whether you wish to make an affirmation, which is a non-religious way of swearing to tell the truth. If you are a witness in a Youth Court you will promise to tell the truth or affirm. You will be asked about other rituals and practices you may want to observe before giving evidence.
+  Oath taking procedures will be explained to you and you will be asked whether you want to swear 
+  to tell the truth on the holy book of your religion or whether you wish to make an affirmation, 
+  which is a non-religious way of swearing to tell the truth. If you are a witness in a Youth Court 
+  you will promise to tell the truth or affirm. You will be asked about other rituals and practices 
+  you may want to observe before giving evidence.
 
-  Light refreshments may be available for you to buy. See the facilities section for more information.
+  Light refreshments may be available for you to buy. See the facilities section for more 
+  information.
 
-  You may have access to en-suite toilet facilities or toilets within close proximity to your waiting area.
+  You may have access to en-suite toilet facilities or toilets within close proximity to your 
+  waiting area.
 
-  We aim to call you to give your evidence within two hours of the start time, although this is not always possible.
+  We aim to call you to give your evidence within two hours of the start time, although this is 
+  not always possible.
 
-  We will provide you with regular updates on the progress of the case and explain the reasons for any delay, where possible. If you are likely to have to wait a long time, the court will consider letting you leave court to return at a later time.
+  We will provide you with regular updates on the progress of the case and explain the reasons for 
+  any delay, where possible. If you are likely to have to wait a long time, the court will 
+  consider letting you leave court to return at a later time.
 
   ##  Giving your evidence
 
-  **You will** be accompanied usually by the court usher or a member of the Witness Service to the courtroom, where you are going to give your evidence.
+  **You will** be accompanied usually by the court usher or a member of the Witness Service to the 
+  courtroom, where you are going to give your evidence.
 
-  In the courtroom, you will be asked by the Court Usher to take the oath or affirm in accordance with the procedures already explained.
+  In the courtroom, you will be asked by the Court Usher to take the oath or affirm in accordance 
+  with the procedures already explained.
 
   If you are not required to give evidence the reason for this will be explained to you.
 
   ##  After you have given your evidence
 
-  When you have finished giving your evidence you will be thanked for attending and will be told whether you are allowed to leave. If you wish to stay and watch the rest of the case, this will be arranged if the Court agrees.
+  When you have finished giving your evidence you will be thanked for attending and will be told 
+  whether you are allowed to leave. If you wish to stay and watch the rest of the case, this will 
+  be arranged if the Court agrees.
 
   ##  After your case has finished
 
-  You will be told the result of your case by the Witness Care Unit who will also be able to provide you with information about any further support you may need.
+  You will be told the result of your case by the Witness Care Unit who will also be able to 
+  provide you with information about any further support you may need.
 
-  You may be able to claim the cost of having to come to court. You can ask the Witness Care Unit which has asked you to come to court for an application form before the trial. You can also request a claim form from the CPS representative at court or the Witness Care Unit after your trial. If you have receipts, you should send these with your claim.
+  You may be able to claim the cost of having to come to court. You can ask the Witness Care Unit 
+  which has asked you to come to court for an application form before the trial. You can also 
+  request a claim form from the CPS representative at court or the Witness Care Unit after your 
+  trial. If you have receipts, you should send these with your claim.
 
-  If the defendant appeals against the decision of the Court, the Witness Care Unit will tell you about this and will explain the procedures involved.
+  If the defendant appeals against the decision of the Court, the Witness Care Unit will tell you 
+  about this and will explain the procedures involved.
 
   ##  Feedback and complaints
 
-  Your comments are important to us. If you wish to provide any feedback on the service you received when attending court or wish to make suggestions as to how we might improve our service, please write to the Court Manager at the Court you have attended - please see contact details for further information.
+  Your comments are important to us. If you wish to provide any feedback on the service you received 
+  when attending court or wish to make suggestions as to how we might improve our service, please 
+  write to the Court Manager at the Court you have attended - please see contact details for further 
+  information.
 
-  If you wish to make a complaint about the service you received, please ask a member of staff at the court or the Court Manager for an EX343 'Complaints leaflet', which you can fill in with the details of your complaint. If you have any comments on this leaflet you can email your comments to [victim.witnessbranch@hmcts.gsi.gov.uk](mailto:victim.witnessbranch@hmcts.gsi.gov.uk).
+  If you wish to make a complaint about the service you received, please ask a member of staff at 
+  the court or the Court Manager for an EX343 'Complaints leaflet', which you can fill in with 
+  the details of your complaint. If you have any comments on this leaflet you can email your 
+  comments to [victim.witnessbranch@hmcts.gsi.gov.uk](mailto:victim.witnessbranch@hmcts.gsi.gov.uk).
 
   ##  What additional help is available for court users with a disability?
 
-  If you have a disability which makes going to court or communicating difficult, please contact a member of staff at the court. If you are deaf or hard of hearing and require assistance the following services can help you once you have obtained the relevant court telephone number: Textphone users calling voicephones or textphones dial 18001, Voicephone users calling textphones or voicephones dial 18002, Text relay service on 0870 240 5152.
+  If you have a disability which makes going to court or communicating difficult, please contact a 
+  member of staff at the court. If you are deaf or hard of hearing and require assistance the 
+  following services can help you once you have obtained the relevant court telephone number: 
+  Textphone users calling voicephones or textphones dial 18001, Voicephone users calling textphones 
+  or voicephones dial 18002, Text relay service on 0870 240 5152.
 
   ##  More information
 
   Further information on going to court can be obtained from:
 
-  **Website:** [www.justice.gov.uk](http://www.justice.gov.uk) - visit the web page on 'Being a Witness'
+  **Website:** [www.justice.gov.uk](http://www.justice.gov.uk) - visit the web page on 
+  'Being a Witness'
 
-  **DVD:** 'Going to Court - A step by step guide to being witness' is available at [http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o](http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o)
+  **DVD:** 'Going to Court - A step by step guide to being witness' is available at 
+  [http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o](http://www.youtube.com/watch?v=aUOc0Sa1WMM&list=TLFjqN6RUpB1o)
 
   **Large print versions of this leaflet are available**
 
-  A generic version of this leaflet (i.e this will not include a map of the local court you have been asked to attend) is available in the following languages: English large print, Welsh, Arabic, Bengali, Cantonese, Gujarati, Hindi, Polish, Punjabi and Urdu.
+  A generic version of this leaflet (i.e this will not include a map of the local court you have 
+  been asked to attend) is available in the following languages: English large print, Welsh, 
+  Arabic, Bengali, Cantonese, Gujarati, Hindi, Polish, Punjabi and Urdu.
 
   ##  Getting to the court
 
-  To plan your route to this court, please visit the Court Information and Addresses section of the Justice Website #{root_url}
-  
-  Choose **#{@court.name}** from the Court Name Search and select Get Court Details. On the Court Information page enter your postcode on the Route Planner on the right- hand side to get a detailed description of your journey by bus, train or car.
+  To plan your route to this court, please visit the Court Information and Addresses section of 
+  the Justice Website #{root_url}
+
+  Choose **#{@court.name}** from the Court Name Search and select Get Court Details. On the 
+  Court Information page enter your postcode on the Route Planner on the right- hand side to get a 
+  detailed description of your journey by bus, train or car.

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -25,7 +25,7 @@
     <br/> 
     <%= f.label :text, "Please take a moment to tell us about your experience, what worked and what didn't." %>
     <%= f.text_area :text, :cols => 50, :rows => 5 %>
-    <br/><span id="char-limit">2000 characters max</span>
+    <br/><span class="char-limit">2000 characters max</span>
     </div>
     <div>
       <%= f.label :email, "Your email address (optional)" %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -4,7 +4,7 @@
   <script>
   $('#feedback_text').keyup(function(){
     var charlimit = 2000,
-        notice = $('#char-limit');
+        notice = $('.char-limit');
     
     if($(this).val().length > charlimit) {
       $(this)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Courtfinder::Application.routes.draw do
     match '/:id/leaflets' => :information, :as => :information
     match '/:id/leaflets/defence' => :defence, :as => :defence
     match '/:id/leaflets/prosecution' => :prosecution, :as => :prosecution
+    match '/:id/leaflets/juror' => :juror, :as => :juror
   end
   scope 'court-types', :controller => :court_types do
     match '/' => :index, :as => :court_types

--- a/db/migrate/20130912110707_add_leaflets_to_courts.rb
+++ b/db/migrate/20130912110707_add_leaflets_to_courts.rb
@@ -1,0 +1,8 @@
+class AddLeafletsToCourts < ActiveRecord::Migration
+  def change
+    add_column :courts, :info_leaflet, :text
+    add_column :courts, :defence_leaflet, :text
+    add_column :courts, :prosecution_leaflet, :text
+    add_column :courts, :juror_leaflet, :text
+  end
+end

--- a/spec/controllers/courts_controller_spec.rb
+++ b/spec/controllers/courts_controller_spec.rb
@@ -4,7 +4,33 @@ describe CourtsController do
   render_views
 
   before :all do
-    @court = Court.create!(:name => 'A court of LAW')
+    @court = FactoryGirl.create(:court, :name => 'A court of LAW')
+    @ct_county = FactoryGirl.create(:court_type, :name => "County Court")
+    @ct_family = FactoryGirl.create(:court_type, :name => "Family Proceedings Court")
+    @ct_tribunal = FactoryGirl.create(:court_type, :name => "Tribunal")
+    @ct_magistrate = FactoryGirl.create(:court_type, :name => "Magistrates' Court")
+    @ct_crown = FactoryGirl.create(:court_type, :name => "Crown Court")
+    @county_court = FactoryGirl.create(:court, :name => 'And Justice For All County Court', 
+                    :info_leaflet => "some useful info",
+                    :court_type_ids => [@ct_county.id], :display => true)
+    @family_court = FactoryGirl.create(:court, :name => 'Capita Family Court', 
+                    :info_leaflet => "some useful info",
+                    :court_type_ids => [@ct_family.id], :display => true)
+    @tribunal = FactoryGirl.create(:court, :name => 'Capita Tribunal', 
+                    :info_leaflet => "some useful info",
+                    :court_type_ids => [@ct_tribunal.id], :display => true)
+    @magistrates_court = FactoryGirl.create(:court, :name => 'Capita Magistrates Court', 
+                    :info_leaflet => "some useful info",
+                    :court_type_ids => [@ct_magistrate.id], :display => true)
+    @crown_court = FactoryGirl.create(:court, :name => 'Capita Crown Court', 
+                    :info_leaflet => "some useful info",
+                    :court_type_ids => [@ct_crown.id], :display => true)
+    @combined_court = FactoryGirl.create(:court, :name => 'Capita Combined Court', 
+                    :info_leaflet => "some useful info",
+                    :court_type_ids => [@ct_county.id, @ct_crown.id], :display => true)
+    @typeless_court = FactoryGirl.create(:court, :name => 'Capita Typeless Court', 
+                    :info_leaflet => "some useful info",
+                    :display => true)
   end
 
   before :each do
@@ -26,6 +52,7 @@ describe CourtsController do
     response.should be_successful
   end
 
+  #Leaflets
   it "redirects to a slug of a defence leaflet" do
     get :defence, id: @court.id
     response.should redirect_to(defence_path(@court))
@@ -56,9 +83,133 @@ describe CourtsController do
     response.should be_successful
   end
 
+  #County courts leaflets
+  it "displays link to information leaflet for County courts" do
+    get :show, id: @county_court.slug
+    expect(response.body).to match /Local information leaflet/m
+  end
+
+  it "does not display link to prosecution witness leaflet for County courts" do
+    get :show, id: @county_court.slug
+    expect(response.body).not_to match /Prosecution witness leaflet/m
+  end
+
+  it "does not display link to defence witness leaflet for County courts" do
+    get :show, id: @county_court.slug
+    expect(response.body).not_to match /Defence witness leaflet/m
+  end
+
+  it "does not display link to juror leaflet for County courts" do
+    get :show, id: @county_court.slug
+    expect(response.body).not_to match /Juror leaflet/m
+  end
+
+  #Crown courts leaflets
+  it "displays link to local sinformation leaflet for Crown courts" do
+    get :show, id: @crown_court.slug
+    expect(response.body).to match /Local information leaflet/m
+  end
+
+  it "displays link to prosecution witness leaflet for Crown courts" do
+    get :show, id: @crown_court.slug
+    expect(response.body).to match /Prosecution witness leaflet/m
+  end
+
+  it "displays link to defence witness leaflet for Crown courts" do
+    get :show, id: @crown_court.slug
+    expect(response.body).to match /Defence witness leaflet/m
+  end
+
+  it "displays link to juror leaflet for Crown courts" do
+    get :show, id: @crown_court.slug
+    expect(response.body).to match /Juror leaflet/m
+  end
+
+  #Magistrates courts leaflets
+  it "displays link to information leaflet for Magistrates courts" do
+    get :show, id: @magistrates_court.slug
+    expect(response.body).to match /Local information leaflet/m
+  end
+
+  it "displays link to prosecution witness leaflet for Magistrates courts" do
+    get :show, id: @magistrates_court.slug
+    expect(response.body).to match /Prosecution witness leaflet/m
+  end
+
+  it "displays link to defence witness leaflet for Magistrates courts" do
+    get :show, id: @magistrates_court.slug
+    expect(response.body).to match /Defence witness leaflet/m
+  end
+
+  it "does not display link to juror leaflet for Magistrates courts" do
+    get :show, id: @magistrates_court.slug
+    expect(response.body).not_to match /Juror leaflet/m
+  end
+
+  #Tribunals leaflets
+  it "displays link to information leaflet for Tribunals" do
+    get :show, id: @tribunal.slug
+    expect(response.body).to match /Local information leaflet/m
+  end
+
+  it "does not display link to prosecution witness leaflet for Tribunals" do
+    get :show, id: @tribunal.slug
+    expect(response.body).not_to match /Prosecution witness leaflet/m
+  end
+
+  it "does not display link to defence witness leaflet for Tribunals" do
+    get :show, id: @tribunal.slug
+    expect(response.body).not_to match /Defence witness leaflet/m
+  end
+
+  it "does not display link to juror leaflet for Tribunals" do
+    get :show, id: @tribunal.slug
+    expect(response.body).not_to match /Juror leaflet/m
+  end
+
+  #Typeless courts leaflets
+  it "displays link to information leaflet for courts without types" do
+    get :show, id: @typeless_court.slug
+    expect(response.body).to match /Local information leaflet/m
+  end
+
+  it "displays link to prosecution witness leaflet for courts without types" do
+    get :show, id: @typeless_court.slug
+    expect(response.body).to match /Prosecution witness leaflet/m
+  end
+
+  it "displays link to defence witness leaflet for courts without types" do
+    get :show, id: @typeless_court.slug
+    expect(response.body).to match /Defence witness leaflet/m
+  end
+
+  it "does not display link to juror leaflet for courts without types" do
+    get :show, id: @typeless_court.slug
+    expect(response.body).not_to match /Juror leaflet/m
+  end
+
+  #Combined courts leaflets
+  it "displays link to information leaflet for Combined courts" do
+    get :show, id: @combined_court.slug
+    expect(response.body).to match /Local information leaflet/m
+  end
+
+  it "displays link to prosecution witness leaflet for Combined courts" do
+    get :show, id: @combined_court.slug
+    expect(response.body).to match /Prosecution witness leaflet/m
+  end
+
+  it "displays link to defence witness leaflet for Combined courts" do
+    get :show, id: @combined_court.slug
+    expect(response.body).to match /Defence witness leaflet/m
+  end
+
+  it "displays link to juror leaflet for Combined courts (with crown court type)" do
+    get :show, id: @combined_court.slug
+    expect(response.body).to match /Juror leaflet/m
+  end
 
   # JSON API
-
   it "returns information if asked for json" do
     get :show, id: @court.slug, format: :json
     response.should be_successful

--- a/spec/models/court_spec.rb
+++ b/spec/models/court_spec.rb
@@ -11,4 +11,31 @@ describe Court do
       Court.search('London').should == [@court1]
     end
   end
+
+  before(:all) do
+    @ct_county = FactoryGirl.create(:court_type, :name => "County Court")
+    @ct_crown = FactoryGirl.create(:court_type, :name => "Crown Court")
+    @ct_magistrate = FactoryGirl.create(:court_type, :name => "Magistrates' Court")
+    @ct_tribunal = FactoryGirl.create(:court_type, :name => "Tribunal")    
+    @county_court = FactoryGirl.create(:court, :name => 'Some County Court', :court_type_ids => [@ct_county.id])
+    @crown_court = FactoryGirl.create(:court, :name => 'Some Crown Court', :court_type_ids => [@ct_crown.id])
+    @magistrates_court = FactoryGirl.create(:court, :name => 'Some Magistrates Court', :court_type_ids => [@ct_magistrate.id])
+    @tribunal = FactoryGirl.create(:court, :name => 'Some Tribunal', :court_type_ids => [@ct_tribunal.id])
+  end
+
+  it "should return no leaflets for County courts" do
+    @county_court.leaflets.should be_empty
+  end
+
+  it "should include defence and prosecution leaflets for Magistrates courts" do
+    @magistrates_court.leaflets.should =~ ["defence", "prosecution"]
+  end
+
+  it "should include defence, prosecution and juror leaflets for Crown courts" do
+    @crown_court.leaflets.should =~ ["defence", "juror", "prosecution"]
+  end
+
+  it "should return no leaflets for Tribunals" do
+    @tribunal.leaflets.should be_empty
+  end
 end


### PR DESCRIPTION
Fix rake tasks for importing and processing court types. Add court type field to admin edit page.

CF-113 Replace 'Update court' button with 'Update'

Fix court type processing rake task. Add court type on court edit page.

Temporarily remove court type field from edit page for server data processing.

fix merge issues

Add comment describing old combined court types ids

Add Tribunal court type to importer. Fix importer bugs.

Fix rake tasks for importing and processing court types. Add court type field to admin edit page.

CF-113 Replace 'Update court' button with 'Update'

Fix court type processing rake task. Add court type on court edit page.

Temporarily remove court type field from edit page for server data processing.

fix merge issues

Add court type field to admin edit page

Show show leaflet links by court type on court show page

Add leaflets fields to Court. Add leaflet edit textareas to admin page.

Display custom info on leaflets.

Show only info leaflets for Tribunals.

fix bug in info leaflet view

fix scheme merge conflict

Add tests for leaflets

Add test for displaying local info leaflet

Add test specs leaflet links for all court types

CF-65 Add juror leaflets for crown courts.
