### PR TITLE
CF-227 Fix: court show views break when no contact type

### DIFF
--- a/app/views/courts/_court_details.html.haml
+++ b/app/views/courts/_court_details.html.haml
@@ -48,7 +48,7 @@
 
   - @court.emails.each do |email|
     %p{:property => "contactPoint", :typeof => "ContactPoint"}
-      - if not email.contact_type.nil? and email.contact_type.name.present?
+      - if email.contact_type and email.contact_type.name.present?
         %span{:property => "contactType"}
           = "#{email.contact_type.name}:"
       = format_email_address email.address


### PR DESCRIPTION
Fixing Nil Email ContactType's in the view as they are optional attributes.
