### PR TITLE
CF-235 Keep an audit trail of data changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,4 @@ gem 'varnish-client', require: 'varnish/client'
 gem 'jbuilder'              # json api templating
 gem 'httparty'
 gem 'appsignal'
+gem 'paper_trail', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,9 @@ GEM
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     orm_adapter (0.4.0)
+    paper_trail (3.0.0)
+      activerecord (>= 3.0, < 5.0)
+      activesupport (>= 3.0, < 5.0)
     pg (0.14.1)
     polyglot (0.3.3)
     rack (1.4.5)
@@ -245,6 +248,7 @@ DEPENDENCIES
   jquery-rails (~> 2.1)
   moj_frontend_toolkit_gem!
   nokogiri
+  paper_trail (~> 3.0)
   pg
   rails (= 3.2.16)
   rdiscount

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,6 +5,8 @@ class Address < ActiveRecord::Base
   attr_accessible :address_line_1, :address_line_2, :address_line_3, :address_line_4, :dx, :name, :postcode, :town_id, :address_type_id, :is_primary, :town
   validates_presence_of :address_line_1, :town
 
+  has_paper_trail :ignore => [:created_at, :updated_at]
+
   scope :visiting, ->() { where(:address_type_id => AddressType.find_by_name("Visiting").id) }
   scope :postal, ->() { where(:address_type_id => AddressType.find_by_name("Postal").id) }
   

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,5 +3,7 @@ class Contact < ActiveRecord::Base
   belongs_to :contact_type
   attr_accessible :in_leaflet, :name, :sort, :telephone, :contact_type_id
 
+  has_paper_trail :ignore => [:created_at, :updated_at]
+
   default_scope :order => :sort
 end

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -24,6 +24,8 @@ class Court < ActiveRecord::Base
   accepts_nested_attributes_for :court_facilities, allow_destroy: true
   validates_presence_of :name
 
+  has_paper_trail :ignore => [:created_at, :updated_at]
+
   extend FriendlyId
   friendly_id :name, use: [:slugged, :history]
 

--- a/app/models/court_facility.rb
+++ b/app/models/court_facility.rb
@@ -2,6 +2,7 @@ class CourtFacility < ActiveRecord::Base
   belongs_to :court
   belongs_to :facility
   attr_accessible :description, :facility_id, :sort
+  has_paper_trail :ignore => [:created_at, :updated_at]
 
   default_scope :order => :sort
 end

--- a/app/models/court_type.rb
+++ b/app/models/court_type.rb
@@ -3,6 +3,8 @@ class CourtType < ActiveRecord::Base
   has_many :court_types_courts
   has_many :courts, :through => :court_types_courts
 
+  has_paper_trail
+  
   extend FriendlyId
   friendly_id :name, use: [:slugged, :history]
   

--- a/app/models/court_types_court.rb
+++ b/app/models/court_types_court.rb
@@ -2,4 +2,5 @@ class CourtTypesCourt < ActiveRecord::Base
   belongs_to :court
   belongs_to :court_type
   attr_accessible :court_id, :court_type_id
+  has_paper_trail
 end

--- a/app/models/courts_areas_of_law.rb
+++ b/app/models/courts_areas_of_law.rb
@@ -2,4 +2,5 @@ class CourtsAreasOfLaw < ActiveRecord::Base
   belongs_to :court
   belongs_to :area_of_law
   attr_accessible :court_id, :area_of_law_id
+  has_paper_trail :ignore => [:created_at, :updated_at]
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -3,6 +3,8 @@ class Email < ActiveRecord::Base
   belongs_to :contact_type
   attr_accessible :address, :sort, :contact_type_id
 
+  has_paper_trail :ignore => [:created_at, :updated_at]
+
   default_scope :order => :sort
 
   def address

--- a/app/models/opening_time.rb
+++ b/app/models/opening_time.rb
@@ -3,5 +3,7 @@ class OpeningTime < ActiveRecord::Base
   belongs_to :opening_type
   attr_accessible :name, :sort, :court_id, :opening_type_id
 
+  has_paper_trail :ignore => [:created_at, :updated_at]
+
   default_scope :order => :sort
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Courtfinder::Application.routes.draw do
         get :areas_of_law
         get :court_types
         get :postcodes
+        get :audit
       end
     end
 

--- a/db/migrate/20140206150730_create_versions.rb
+++ b/db/migrate/20140206150730_create_versions.rb
@@ -1,0 +1,18 @@
+class CreateVersions < ActiveRecord::Migration
+  def self.up
+    create_table :versions do |t|
+      t.string   :item_type, :null => false
+      t.integer  :item_id,   :null => false
+      t.string   :event,     :null => false
+      t.string   :whodunnit
+      t.text     :object
+      t.datetime :created_at
+    end
+    add_index :versions, [:item_type, :item_id]
+  end
+
+  def self.down
+    remove_index :versions, [:item_type, :item_id]
+    drop_table :versions
+  end
+end

--- a/db/migrate/20140206150731_add_object_changes_column_to_versions.rb
+++ b/db/migrate/20140206150731_add_object_changes_column_to_versions.rb
@@ -1,0 +1,9 @@
+class AddObjectChangesColumnToVersions < ActiveRecord::Migration
+  def self.up
+    add_column :versions, :object_changes, :text
+  end
+
+  def self.down
+    remove_column :versions, :object_changes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -278,4 +278,16 @@ ActiveRecord::Schema.define(:version => 20140205163110) do
   add_index "users", ["invited_by_id"], :name => "index_users_on_invited_by_id"
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
+  create_table "versions", :force => true do |t|
+    t.string   "item_type",      :null => false
+    t.integer  "item_id",        :null => false
+    t.string   "event",          :null => false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+    t.text     "object_changes"
+  end
+
+  add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"
+
 end


### PR DESCRIPTION
Ignore create, update datetime fields. No before value for create action.

Restrict association changeset method to super-admin

Fix specs for audit trail csv.

5000 times faster thanks to flappy bird.
