### PR TITLE
Home page placeholder amendment

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
 			<legend class="visuallyhidden">Postcode lookup</legend>
 			<div class="ask_location">
 				<label for="search-main">Enter a UK postcode, court or tribunal name<br />
-					<input class="postcode" id="search-main" name="q" type="text" placeholder="eg SW1H 9AJ or Luton" autocomplete="off" />
+					<input class="postcode" id="search-main" name="q" type="text" placeholder="e.g. SW1H9AJ or Liverpool Crown Court" autocomplete="off" />
 				</label>
 
 				<div id="results"></div>


### PR DESCRIPTION
Replaced ‘eg SW1H 9AJ or Luton’ with ‘e.g. SW1H9AJ or Liverpool Crown
Court’. PivotalTracker Ref:68588254
