### PR TITLE
71943052 - Move building location section

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 -------------------
 * 70929866 - Landing page for each aread of law
 * Moved to poltergeist for jenkins build support
+* 71943052 - Court page "Location of the building" section moved up to below "Phone" section
 
 2.10.1
 -------------------

--- a/app/views/courts/_court_details.html.haml
+++ b/app/views/courts/_court_details.html.haml
@@ -67,7 +67,23 @@
         = enforce_label type
       = contacts_as_group contacts
 
+-# === Map ===
+- if @court.locatable?
+  %div.court-location-wrapper
+    %h2#location Location of the building
+    %meta{:property => "map", :content => "http://maps.google.co.uk/maps?q=loc:#{@court.latitude}+#{@court.longitude}" }
+    %form#directions.hidden-print{:action => "http://maps.google.co.uk/maps", :method => "get", :rel => "ext"}
+      %label{:for => "saddr"} Enter a town or postcode to get directions
+      %p
+        %input{:name => "saddr", :type => "text", :value => params[:from]}
+        %input{:name => "daddr", :type => "hidden", :value => "#{@court.latitude},#{@court.longitude}"}
+        %input{:type => "submit", :value => "Get directions", :class => "button" }
 
+    %div.hidden-print
+      = gmaps({ "markers" => { "data" => @court.to_gmaps4rails }, "map_options" => { "auto_zoom" => false, "zoom" => 15 } })
+
+    %div.static-map.visible-print
+      %img{ :src => "http://maps.googleapis.com/maps/api/staticmap?center=#{@court.latitude},#{@court.longitude}&zoom=15&size=600x400&markers=#{@court.latitude},#{@court.longitude}&sensor=false" }
 
 -# === Areas of law ===
 - if @court.areas_of_law.present?
@@ -107,25 +123,6 @@
 - unless print_view
   -# === Print links ===
   = render 'court_leaflets'
-
--# === Map ===
-- if @court.locatable?
-  %div.court-location-wrapper
-    %h2#location Location of the building
-    %meta{:property => "map", :content => "http://maps.google.co.uk/maps?q=loc:#{@court.latitude}+#{@court.longitude}" }
-    %form#directions.hidden-print{:action => "http://maps.google.co.uk/maps", :method => "get", :rel => "ext"}
-      %label{:for => "saddr"} Enter a town or postcode to get directions
-      %p
-        %input{:name => "saddr", :type => "text", :value => params[:from]}
-        %input{:name => "daddr", :type => "hidden", :value => "#{@court.latitude},#{@court.longitude}"}
-        %input{:type => "submit", :value => "Get directions", :class => "button" }
-
-    %div.hidden-print
-      = gmaps({ "markers" => { "data" => @court.to_gmaps4rails }, "map_options" => { "auto_zoom" => false, "zoom" => 15 } })
-
-    %div.static-map.visible-print
-      %img{ :src => "http://maps.googleapis.com/maps/api/staticmap?center=#{@court.latitude},#{@court.longitude}&zoom=15&size=600x400&markers=#{@court.latitude},#{@court.longitude}&sensor=false" }
-
 
 -# === Court info ===
 - if @court.info.present?


### PR DESCRIPTION
Court page "Location of the building" section moved up to between
‘Phone” and “Areas of law covered” sections.
