### PR TITLE
Order councils alphabetically in export scripts

### DIFF
--- a/script/admin-db-to-json.py
+++ b/script/admin-db-to-json.py
@@ -187,7 +187,8 @@ class Data:
                         AND ccl.area_of_law_id = aol.id
                         AND ccl.council_id = co.id
                         AND c.slug = '%s'
-                        AND aol.name = '%s'""" % (slug, aol_name)
+                        AND aol.name = '%s'
+                      ORDER BY co.name""" % (slug, aol_name)
             cur.execute(sql)
             councils = [c[0] for c in cur.fetchall()]
             aols.append({

--- a/script/db-to-s3.py
+++ b/script/db-to-s3.py
@@ -130,7 +130,8 @@ def areas_of_law_for_court( slug ):
                     AND ccl.area_of_law_id = aol.id
                     AND ccl.council_id = co.id
                     AND c.slug = '%s'
-                    AND aol.name = '%s'""" % (slug, aol_name)
+                    AND aol.name = '%s'
+                  ORDER BY co.name""" % (slug, aol_name)
 
         cur.execute(sql)
         councils = [c[0] for c in cur.fetchall()]


### PR DESCRIPTION
This is a prerequisite for the work on replacing the `CourtCouncilLink` model with `Remit` and `Jurisdiction`.
