### PR TITLE
Update the GOV.UK style guide link for the dates and times advice

### DIFF
--- a/app/views/admin/courts/_form.html.haml
+++ b/app/views/admin/courts/_form.html.haml
@@ -90,7 +90,7 @@
           %p
             Please adhere to the GOV.UK content design principles when
             = succeed '.' do
-              %a{:href => "https://www.gov.uk/designprinciples/styleguide#dates-and-times", :rel => "ext help"} entering dates and times
+              %a{:href => "https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times", :rel => "ext help"} entering dates and times
           %ul.sortable
             = f.simple_fields_for :opening_times do |builder|
               = render 'opening_time_fields', f: builder


### PR DESCRIPTION
- This was pointing to the old location of the style guide and the
  anchor had changed from #dates-and-times to #style-dates-and-times.
