### PR TITLE
Include the anchor for phone numbers in the style guide link

### DIFF
--- a/app/views/admin/courts/_form.html.haml
+++ b/app/views/admin/courts/_form.html.haml
@@ -102,7 +102,7 @@
           %p
             List phone number for enquiries first. No duplicate phone numbers. Please adhere to the GOV.UK content design principles when
             = succeed '.' do
-              %a{:href => "https://www.gov.uk/design-principles/style-guide/style-points"} entering phone numbers
+              %a{:href => "https://www.gov.uk/design-principles/style-guide/style-points#style-phone-numbers"} entering phone numbers
           %ul.sortable
             = f.simple_fields_for :contacts do |builder|
               = render 'contact_fields', f: builder


### PR DESCRIPTION
This section is near the bottom of the page, so users are more likely
to read it if they are taken straight to it.
