### PR TITLE
Heartbeat controller with healthcheck endpoint

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,0 +1,22 @@
+class HeartbeatController < ApplicationController
+  def healthcheck
+    checks = {
+      database: database_alive?
+    }
+
+    status = :bad_gateway unless checks.values.all?
+    render status: status, json: {
+      checks: checks
+    }
+  end
+
+  private
+
+  def database_alive?
+    begin
+      ActiveRecord::Base.connection.active?
+    rescue PG::ConnectionBad
+      false
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Courtfinder::Application.routes.draw do
 
+  get 'admin/healthcheck', to: 'heartbeat#healthcheck', as: 'healthcheck', format: :json
+
   # Public court pages
   # TODO: This needs tidying
   scope 'courts', :controller => :courts do

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe HeartbeatController, type: :controller do
+  describe '#healthcheck' do
+    context 'when a problem exists' do
+      before(:each) do
+        expect(ActiveRecord::Base.connection).to receive(:active?).once.and_raise(PG::ConnectionBad)
+        get :healthcheck
+      end
+
+      let(:expected_response) do
+        {
+          checks: { database: false }
+        }.to_json
+      end
+
+      it 'returns status bad gateway' do
+        expect(response.status).to eq(502)
+      end
+
+      it 'returns the expected response report' do
+        expect(response.body).to eq(expected_response)
+      end
+    end
+
+    context 'when everything is ok' do
+      before do
+        get :healthcheck
+      end
+
+      let(:expected_response) do
+        {
+          checks: { database: true }
+        }.to_json
+      end
+
+      it 'returns HTTP success' do
+        get :healthcheck
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns the expected response report' do
+        get :healthcheck
+        expect(response.body).to eq(expected_response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
/admin/healthcheck.json endpoint to return status of dependant services (currently only the database).

```
{
  "checks" :
    {
      "database" : true
    }
}
```
