### PR TITLE
Courts JSON exporter and rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,8 @@ gem 'geocoder'              # Check distances with latitude and longitude
 gem 'devise', '~>3.4.1'     # Authentication
 gem 'devise_invitable'      # Authentication invites
 gem 'rmagick', require: false # Resize uploaded images
-#gem 'fog', '1.20.0'                   # Talks to cloud providers (e.g. S3)
+gem 'fog', '1.20.0'                   # Talks to cloud providers (e.g. S3)
+gem 'unf'
 gem 'carrierwave', github: 'carrierwaveuploader/carrierwave', branch: 'master'           # Handles file uploads
 gem 'carrierwave-aws'
 gem 'gmaps4rails', '~>1.5.6'# Maps and directions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     eventmachine (1.0.4)
+    excon (0.31.0)
     execjs (2.2.2)
     extlib (0.9.16)
     factory_girl (4.5.0)
@@ -163,6 +164,15 @@ GEM
     ffi (1.9.6)
     figaro (1.0.0)
       thor (~> 0.14)
+    fog (1.20.0)
+      builder
+      excon (~> 0.31.0)
+      formatador (~> 0.2.0)
+      mime-types
+      multi_json (~> 1.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+      nokogiri (>= 1.5.11)
     formatador (0.2.5)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
@@ -255,6 +265,9 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.1.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
     netrc (0.10.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
@@ -409,6 +422,9 @@ GEM
     uglifier (2.6.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -454,6 +470,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   figaro
+  fog (= 1.20.0)
   friendly_id (~> 5.0.0)
   geocoder
   global_phone
@@ -497,6 +514,7 @@ DEPENDENCIES
   simplecov
   timecop
   uglifier (>= 1.0.3)
+  unf
   unicorn
   vcr
   verbs

--- a/app/services/courts_json_exporter.rb
+++ b/app/services/courts_json_exporter.rb
@@ -81,15 +81,13 @@ class CourtsJsonExporter
 
   def build_addresses(court)
     court.addresses.inject([]) do |collection, address|
-      address_hash = {
+      collection << {
         'town'      => address.town.name,
         'county'    => address.town.county.name,
         'type'      => address.address_type.name,
         'postcode'  => address.postcode,
         'address'   => address.lines.join("\n")
       }
-
-      collection << address_hash
     end
   end
 
@@ -101,39 +99,33 @@ class CourtsJsonExporter
 
   def build_contacts(court)
     court.contacts.unscope(:order).inject([]) do |collection, contact|
-      contact_hash = {
+      collection << {
         'sort'    => contact.sort,
         'name'    => contact.contact_type.name,
         'number'  => contact.telephone
       }
-
-      collection << contact_hash
     end
   end
 
   def build_emails(court)
     court.emails.unscope(:order).inject([]) do |collection, email|
       if email.contact_type
-        email_hash = {
+        collection << {
           'description' => email.contact_type.name,
           'address'     => email.address
         }
-
-        collection << email_hash
       end
     end
   end
 
   def build_facilities(court)
     court.court_facilities.unscope(:order).inject([]) do |collection, court_facility|
-      court_facility_hash = {
+      collection << {
         'image_description'   => court_facility.facility.image_description,
         'image'               => court_facility.facility.image,
         'description'         => court_facility.description,
         'name'                => court_facility.facility.name
       }
-
-      collection << court_facility_hash
     end
   end
 

--- a/app/services/courts_json_exporter.rb
+++ b/app/services/courts_json_exporter.rb
@@ -1,0 +1,179 @@
+require 'json'
+require 'fog'
+
+class CourtsJsonExporter
+  PARKING_TYPES = {
+    'parking_onsite_free'           => 'Free on site parking is available at this venue.',
+    'parking_onsite_paid'           => 'Paid on site parking is available at this venue.',
+    'parking_onsite_none'           => 'On site parking is not available at this venue.',
+    'parking_offsite_free'          => 'Free off site parking is available within 500m of this venue.',
+    'parking_offsite_paid'          => 'Paid off site parking is available within 500m of this venue.',
+    'parking_offsite_none'          => 'Off site parking is not available within 500m of this venue.',
+    'parking_blue_badge_available'  => 'Blue badge parking is available on site.',
+    'parking_blue_badge_limited'    => 'Limited blue badge parking is available on site (please contact the venue for details).',
+    'parking_blue_badge_none'       => 'Blue badge parking is not available at this venue.'
+  }
+
+  def export!
+    json = build_courts_json
+
+    fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'eu-west-1'
+    }
+
+    connection = Fog::Storage.new(fog_credentials)
+    s3 = connection.directories.get(ENV['APP_S3_BUCKET'])
+    s3.files.create(key: 'courts.json', body: json)
+  end
+
+  def build_courts_json
+    JSON.pretty_generate(build_courts, indent: '    ')
+  end
+
+  def build_courts
+    courts.inject([]) do |collection, court|
+      court_hash = {}
+
+      court_hash['addresses'] = build_addresses(court)
+      court_hash['updated_at'] = court.updated_at_before_type_cast if court.updated_at.present?
+      court_hash['admin_id'] = court.id
+      court_hash['facilities'] = build_facilities(court)
+      court_hash['lat'] = court.latitude.to_s if court.latitude.present?
+      court_hash['cci_code'] = court.cci_code if court.cci_code.present?
+      court_hash['slug'] = court.slug
+      court_hash['opening_times'] = build_opening_times(court) if build_opening_times(court)
+      court_hash['court_types'] = build_court_types(court)
+      court_hash['name'] = court.name
+      court_hash['contacts'] = build_contacts(court)
+      court_hash['created_at'] = court.created_at_before_type_cast if court.created_at.present?
+      court_hash['court_number'] = court.court_number
+      court_hash['lon'] = court.longitude.to_s if court.longitude.present?
+      court_hash['postcodes'] = build_postcodes(court)
+      court_hash['emails'] = build_emails(court) || []
+      court_hash['areas_of_law'] = build_areas_of_law(court)
+      court_hash['display'] = court.display
+      court_hash['image_file'] = court.image_file if court.image_file.present?
+      court_hash['alert'] = court.alert if court.alert.present?
+      court_hash['parking'] = build_parking(court) if build_parking(court).any?
+      court_hash['directions'] = court.directions if court.directions.present?
+
+      collection << court_hash
+    end
+  end
+
+  private
+
+  def build_parking(court)
+    parking = {}
+    parking['onsite'] =  PARKING_TYPES[court.parking_onsite] if court.parking_onsite.present?
+    parking['offsite'] =  PARKING_TYPES[court.parking_offsite] if court.parking_offsite.present?
+    parking['blue_badge'] =  PARKING_TYPES[court.parking_blue_badge] if court.parking_blue_badge.present?
+    parking
+  end
+
+  def build_areas_of_law(court)
+    court.areas_of_law.unscope(:order).order(id: :asc).inject([]) do |collection, area_of_law|
+      area_of_law_hash = {}
+      area_of_law_hash['name'] = area_of_law.name
+      area_of_law_hash['slug'] = area_of_law.slug
+
+      remit = Remit.find_by(court_id: court.id, area_of_law_id: area_of_law.id)
+      area_of_law_hash['single_point_of_entry'] = remit.single_point_of_entry if remit && remit.single_point_of_entry.present?
+
+      local_authorities = court.area_local_authorities_list(area_of_law)
+      local_authorities = [] if local_authorities.blank?
+      area_of_law_hash['local_authorities'] = local_authorities.sort
+
+      collection << area_of_law_hash
+    end
+  end
+
+  def build_addresses(court)
+    court.addresses.inject([]) do |collection, address|
+      address_hash = {
+        'town'      => address.town.name,
+        'county'    => address.town.county.name,
+        'type'      => address.address_type.name,
+        'postcode'  => address.postcode,
+        'address'   => address.lines.join("\n")
+      }
+
+      collection << address_hash
+    end
+  end
+
+  def build_court_types(court)
+    court.court_types.inject([]) do |collection, court_type|
+      collection << court_type.name
+    end
+  end
+
+  def build_contacts(court)
+    court.contacts.unscope(:order).inject([]) do |collection, contact|
+      contact_hash = {
+        'sort'    => contact.sort,
+        'name'    => contact.contact_type.name,
+        'number'  => contact.telephone
+      }
+
+      collection << contact_hash
+    end
+  end
+
+  def build_emails(court)
+    court.emails.unscope(:order).inject([]) do |collection, email|
+      if email.contact_type
+        email_hash = {
+          'description' => email.contact_type.name,
+          'address'     => email.address
+        }
+
+        collection << email_hash
+      end
+    end
+  end
+
+  def build_facilities(court)
+    court.court_facilities.unscope(:order).inject([]) do |collection, court_facility|
+      court_facility_hash = {
+        'image_description'   => court_facility.facility.image_description,
+        'image'               => court_facility.facility.image,
+        'description'         => court_facility.description,
+        'name'                => court_facility.facility.name
+      }
+
+      collection << court_facility_hash
+    end
+  end
+
+  def build_postcodes(court)
+    court.postcode_courts.inject([]) do |collection, postcode_court|
+      collection << postcode_court.postcode
+    end
+  end
+
+  def build_opening_times(court)
+    court.opening_times.unscope(:order).inject([]) do |collection, opening_time|
+      collection << "#{opening_time.opening_type.name}: #{opening_time.name}"
+    end
+  end
+
+  def courts
+    Court.includes(
+      :court_types_courts,
+      :court_types,
+      :remits,
+      :postcode_courts,
+      area: :region,
+      opening_times: :opening_type,
+      areas_of_law: :remits,
+      court_facilities: :facility,
+      emails: :contact_type,
+      contacts: :contact_type,
+      addresses: [:address_type, town: :county]
+    )
+  end
+end

--- a/app/services/courts_json_exporter.rb
+++ b/app/services/courts_json_exporter.rb
@@ -2,18 +2,6 @@ require 'json'
 require 'fog'
 
 class CourtsJsonExporter
-  PARKING_TYPES = {
-    'parking_onsite_free'           => 'Free on site parking is available at this venue.',
-    'parking_onsite_paid'           => 'Paid on site parking is available at this venue.',
-    'parking_onsite_none'           => 'On site parking is not available at this venue.',
-    'parking_offsite_free'          => 'Free off site parking is available within 500m of this venue.',
-    'parking_offsite_paid'          => 'Paid off site parking is available within 500m of this venue.',
-    'parking_offsite_none'          => 'Off site parking is not available within 500m of this venue.',
-    'parking_blue_badge_available'  => 'Blue badge parking is available on site.',
-    'parking_blue_badge_limited'    => 'Limited blue badge parking is available on site (please contact the venue for details).',
-    'parking_blue_badge_none'       => 'Blue badge parking is not available at this venue.'
-  }
-
   def export!
     json = build_courts_json
 
@@ -68,9 +56,9 @@ class CourtsJsonExporter
 
   def build_parking(court)
     parking = {}
-    parking['onsite'] =  PARKING_TYPES[court.parking_onsite] if court.parking_onsite.present?
-    parking['offsite'] =  PARKING_TYPES[court.parking_offsite] if court.parking_offsite.present?
-    parking['blue_badge'] =  PARKING_TYPES[court.parking_blue_badge] if court.parking_blue_badge.present?
+    parking['onsite'] =  I18n.t(court.parking_onsite) if court.parking_onsite.present?
+    parking['offsite'] =  I18n.t(court.parking_offsite) if court.parking_offsite.present?
+    parking['blue_badge'] =  I18n.t(court.parking_blue_badge) if court.parking_blue_badge.present?
     parking
   end
 

--- a/app/services/courts_json_exporter.rb
+++ b/app/services/courts_json_exporter.rb
@@ -23,30 +23,29 @@ class CourtsJsonExporter
 
   def build_courts
     courts.inject([]) do |collection, court|
-      court_hash = {}
-
-      court_hash['addresses'] = build_addresses(court)
-      court_hash['updated_at'] = court.updated_at_before_type_cast if court.updated_at.present?
-      court_hash['admin_id'] = court.id
-      court_hash['facilities'] = build_facilities(court)
-      court_hash['lat'] = court.latitude.to_s if court.latitude.present?
-      court_hash['cci_code'] = court.cci_code if court.cci_code.present?
-      court_hash['slug'] = court.slug
-      court_hash['opening_times'] = build_opening_times(court) if build_opening_times(court)
-      court_hash['court_types'] = build_court_types(court)
-      court_hash['name'] = court.name
-      court_hash['contacts'] = build_contacts(court)
-      court_hash['created_at'] = court.created_at_before_type_cast if court.created_at.present?
-      court_hash['court_number'] = court.court_number
-      court_hash['lon'] = court.longitude.to_s if court.longitude.present?
-      court_hash['postcodes'] = build_postcodes(court)
-      court_hash['emails'] = build_emails(court) || []
-      court_hash['areas_of_law'] = build_areas_of_law(court)
-      court_hash['display'] = court.display
-      court_hash['image_file'] = court.image_file if court.image_file.present?
-      court_hash['alert'] = court.alert if court.alert.present?
-      court_hash['parking'] = build_parking(court) if build_parking(court).any?
-      court_hash['directions'] = court.directions if court.directions.present?
+      court_hash                    = {}
+      court_hash['addresses']       = build_addresses(court)
+      court_hash['updated_at']      = court.updated_at_before_type_cast if court.updated_at.present?
+      court_hash['admin_id']        = court.id
+      court_hash['facilities']      = build_facilities(court)
+      court_hash['lat']             = court.latitude.to_s if court.latitude.present?
+      court_hash['cci_code']        = court.cci_code if court.cci_code.present?
+      court_hash['slug']            = court.slug
+      court_hash['opening_times']   = build_opening_times(court) if build_opening_times(court)
+      court_hash['court_types']     = build_court_types(court)
+      court_hash['name']            = court.name
+      court_hash['contacts']        = build_contacts(court)
+      court_hash['created_at']      = court.created_at_before_type_cast if court.created_at.present?
+      court_hash['court_number']    = court.court_number
+      court_hash['lon']             = court.longitude.to_s if court.longitude.present?
+      court_hash['postcodes']       = build_postcodes(court)
+      court_hash['emails']          = build_emails(court) || []
+      court_hash['areas_of_law']    = build_areas_of_law(court)
+      court_hash['display']         = court.display
+      court_hash['image_file']      = court.image_file if court.image_file.present?
+      court_hash['alert']           = court.alert if court.alert.present?
+      court_hash['parking']         = build_parking(court) if build_parking(court).any?
+      court_hash['directions']      = court.directions if court.directions.present?
 
       collection << court_hash
     end

--- a/lib/tasks/export_courts_json.rake
+++ b/lib/tasks/export_courts_json.rake
@@ -1,0 +1,6 @@
+namespace :export do
+  desc 'Export courts.json to S3 bucket'
+  task courts: :environment do
+    CourtsJsonExporter.new.export!
+  end
+end

--- a/spec/services/courts_json_exporter_spec.rb
+++ b/spec/services/courts_json_exporter_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe CourtsJsonExporter do
+  subject { CourtsJsonExporter.new }
+  let!(:courts) { create_list(:court, 20) }
+
+  describe '#build_courts_json' do
+    it 'produces JSON from the courts hashes' do
+      courts = subject.build_courts
+      json = subject.build_courts_json
+      expect(JSON.parse(json)).to eq(courts)
+    end
+  end
+
+  describe '#build_courts' do
+    let(:courts_hash) { subject.build_courts }
+    let(:expected_keys) do
+      [
+        'addresses',
+        'updated_at',
+        'admin_id',
+        'facilities',
+        'lat',
+        'slug',
+        'opening_times',
+        'court_types',
+        'name',
+        'contacts',
+        'created_at',
+        'court_number',
+        'lon',
+        'postcodes',
+        'emails',
+        'areas_of_law',
+        'display'
+      ]
+    end
+
+    it 'has the expected keys' do
+      courts_hash.each do |hash|
+        expect(hash.keys & expected_keys).to eq(expected_keys)
+      end
+    end
+
+    it 'has a matching hash for each court' do
+      courts_hash.each do |hash|
+        court = Court.find(hash['admin_id'])
+        expect(court).to_not be_nil
+        expect(court.name).to eq(hash['name'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces admin-db-to-json.py Python script. Exports court data as JSON for consumption by courtfinder-search using ActiveRecord.

Rake task can be called via:
```
bundle exec rake export:courts
```

AWS S3 specific environment variables must be set for export to succeed:
```
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
APP_S3_BUCKET
```

The Cron job can be updated to call the above Rake task, replacing the Python script. Courts JSON building and export is also now available from within the Courtfinder Rails app.
