### PR TITLE
Make #build_areas_of_law more edge-case tolerant

### DIFF
--- a/app/services/courts_json_exporter.rb
+++ b/app/services/courts_json_exporter.rb
@@ -72,7 +72,7 @@ class CourtsJsonExporter
 
       local_authorities = court.area_local_authorities_list(area_of_law)
       local_authorities = [] if local_authorities.blank?
-      area_of_law_hash['local_authorities'] = local_authorities.sort
+      area_of_law_hash['local_authorities'] = [local_authorities].flatten.sort
 
       collection << area_of_law_hash
     end

--- a/spec/services/courts_json_exporter_spec.rb
+++ b/spec/services/courts_json_exporter_spec.rb
@@ -15,30 +15,17 @@ describe CourtsJsonExporter do
   describe '#build_courts' do
     let(:courts_hash) { subject.build_courts }
     let(:expected_keys) do
-      [
-        'addresses',
-        'updated_at',
-        'admin_id',
-        'facilities',
-        'lat',
-        'slug',
-        'opening_times',
-        'court_types',
-        'name',
-        'contacts',
-        'created_at',
-        'court_number',
-        'lon',
-        'postcodes',
-        'emails',
-        'areas_of_law',
-        'display'
-      ]
+      %w{
+          addresses admin_id areas_of_law
+          contacts court_number court_types created_at
+          display emails facilities lat lon name
+          opening_times postcodes slug updated_at
+      }
     end
 
     it 'has the expected keys' do
       courts_hash.each do |hash|
-        expect(hash.keys & expected_keys).to eq(expected_keys)
+        expect(hash.keys).to match_array(expected_keys)
       end
     end
 
@@ -50,4 +37,22 @@ describe CourtsJsonExporter do
       end
     end
   end
+
+  describe '#build_areas_of_law' do
+    describe 'calls court.area_local_authorities_list' do
+      let(:court) { create(:court, areas_of_law: create_list(:area_of_law, 1)) }
+
+      context 'and that returns a string instead of an array' do
+          before do
+            expect(court).to receive(:area_local_authorities_list).and_return('A string')
+          end
+
+        it 'but #build_areas_of_law does not break' do
+          expect{ subject.send(:build_areas_of_law, court) }.not_to raise_error
+        end
+      end  # context 'and it returns a string instead of an array'
+    end
+  end
+
+
 end


### PR DESCRIPTION
When I tried the exporter on staging, I discovered that at least one
court.area_local_authorities_list call was returning a string instead of
an array. There was no obvious reason for this, so I decided that it was
better to make the exproter tolerate the condition than it was to try
and get to the underlying cause.  This is the result of that work.