### PR TITLE
Make ruby exporter return list of local authorities

### DIFF
--- a/app/services/courts_json_exporter.rb
+++ b/app/services/courts_json_exporter.rb
@@ -72,7 +72,7 @@ class CourtsJsonExporter
 
       local_authorities = court.area_local_authorities_list(area_of_law)
       local_authorities = [] if local_authorities.blank?
-      area_of_law_hash['local_authorities'] = [local_authorities].flatten.sort
+      area_of_law_hash['local_authorities'] = [local_authorities.split(/\s*,\s*/)].flatten.sort
 
       collection << area_of_law_hash
     end

--- a/spec/services/courts_json_exporter_spec.rb
+++ b/spec/services/courts_json_exporter_spec.rb
@@ -43,16 +43,24 @@ describe CourtsJsonExporter do
       let(:court) { create(:court, areas_of_law: create_list(:area_of_law, 1)) }
 
       context 'and that returns a string instead of an array' do
-          before do
-            expect(court).to receive(:area_local_authorities_list).and_return('A string')
-          end
+        before do
+          expect(court).to receive(:area_local_authorities_list).and_return('A string')
+        end
 
         it 'but #build_areas_of_law does not break' do
           expect{ subject.send(:build_areas_of_law, court) }.not_to raise_error
         end
       end  # context 'and it returns a string instead of an array'
+
+      context 'and that returns a string with a comma separated list of multiple local authorities' do
+        before do
+          expect(court).to receive(:area_local_authorities_list).and_return('area 1, area 2')
+        end
+
+        it 'then #build_areas_of_law breaks them out into a list' do
+          expect(subject.send(:build_areas_of_law, court)[0]['local_authorities']).to match_array(['area 1','area 2'])
+        end
+      end
     end
   end
-
-
 end


### PR DESCRIPTION
The application proper returns these as a comma separated list in a
string  The python exporter was converting them to a json list, but the
ruby exporter was not. I added a test and fixed this.