### PR TITLE
Fix assets digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,13 @@ EXPOSE $UNICORN_PORT
 
 COPY run.sh /run.sh
 RUN chmod +x /run.sh
+
+## Django setup
+ENV DJANGO_SETTINGS_MODULE courtfinder.settings.production
+## Rails setup
+ENV RAILS_ENV production
+# Precompile assets in here to setup digest
+RUN RAILS_ENV=production bundle exec rake assets:clean assets:precompile
+
 CMD /run.sh
+

--- a/run.sh
+++ b/run.sh
@@ -24,5 +24,4 @@ create)
     ;;
 esac
 bundle exec rake import:all
-RAILS_ENV=production bundle exec rake assets:precompile
 bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
We need to precompile the assets in the docker build so that our
assets digests will match up with the ones generated within the page.