### PR TITLE
Separate out the one time database import

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ create)
     bundle exec rake db:create
     bundle exec rake db:migrate
     bundle exec rake db:seed
+    bundle exec rake import:all
     ;;
 esac
-bundle exec rake import:all
 bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
There is already a create task for creating the database,
this change moves the data import stage into this task instead
of running every container start.