### PR TITLE
Fix the admin database name

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,8 +26,8 @@ test:
 
 production:
   adapter: postgresql
-  username: courtfinder
-  database: courtfinder_search
+  username: <%= ENV['DB_USERNAME'] || 'courtfinder' %>
+  database: <%= ENV['DB_NAME'] || 'courtfinder_admin' %>
   host: <%= ENV['DB_HOST'] || 'database' %>
   pool: 5
   timeout: 5000


### PR DESCRIPTION
Currently this uses the search database, it should be using its
own separate one.