### PR TITLE
Fix admin database export script

### DIFF
--- a/script/json_export_cron_wrapper.sh
+++ b/script/json_export_cron_wrapper.sh
@@ -1,2 +1,7 @@
 cd "$(dirname "$0")"
-/usr/bin/python ./admin-db-to-json.py --db $DB_NAME --host $DB_HOST --user $DB_USERNAME --password $DB_PASSWORD --access $AWS_ACCESS_KEY --secret $AWS_SECRET_KEY --bucket $S3_BUCKET
+/usr/bin/python ./admin-db-to-json.py \
+	--db $DB_NAME \
+	--host $DB_HOST \
+	--user $DB_USERNAME \
+	--password $DB_PASSWORD \
+	--bucket $S3_BUCKET

--- a/script/requirements.txt
+++ b/script/requirements.txt
@@ -1,5 +1,8 @@
+boto3==1.2.3
+Django==1.9.1
 futures==2.2.0
 psycopg2==2.5.4
+requests==2.6.0
 tinys3==0.1.11
 wsgiref==0.1.2
-requests==2.6.0
+


### PR DESCRIPTION
* Strip None entries from addresses before joining them
* Reinstate django as the json parser to fix datetime to json
* Use a bucket name if we have one and attempt to connect assuming
IAM permissions
* Drop AWS access and secrets as an option
* Add logging noise
* Use boto3 to make the S3 connection, this avoids issues around
a  boto bug that means we get a 307 response from S3 before we've
finished sending the courts data, so we never see the response
and the connection times out and is closed.