### PR TITLE
rake court:source_images from s3 not old site

### DIFF
--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -132,7 +132,7 @@ class Court < ActiveRecord::Base
 
   def fetch_image_file
     if image.present?
-      self.image_file.download!("https://hmctscourtfinder.justice.gov.uk/courtfinder/images/courts/#{self.image.to_s}")
+      self.image_file.download!("https://courtfinder-servicegovuk-production.s3.amazonaws.com/images/#{self.slug.underscore}.jpg")
       self.image_file.store!
     end
   end


### PR DESCRIPTION
- SSL cert expired on old site, breaking the rake task which retrieves images
- They're also stored in an s3 bucket; which is now also used in the rake task
- Some images still fail to download; this is where the court has either closed or changed name