### PR TITLE
Updating error message and missing image on edit.

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -15,8 +15,7 @@
 class Facility < ActiveRecord::Base
   has_many :court_facilities
   attr_accessible :image, :name, :image_description, :image_file
-  validates :image_file, presence: true
-  validate :image_dimensions
+  validate :image_file_validations
 
   default_scope { order('LOWER(name)') } # ignore case when sorting
 
@@ -24,9 +23,12 @@ class Facility < ActiveRecord::Base
 
   private
 
-  def image_dimensions
-    return if self.image_file.blank?
-    if self.image_file.width != 50 && self.image_file.height != 50
+  def image_file_validations
+    if self.image_file.blank?
+      errors.add(:image_file, I18n.t('activerecord.errors.models.facility.attributes.image_file_blank'))
+    elsif self.image_file.file.extension.downcase != 'png'
+      errors.add(:image_file, I18n.t('activerecord.errors.models.facility.attributes.image_file_extension'))
+    elsif self.image_file.width != 50 && self.image_file.height != 50
       errors.add(:image_file, I18n.t('activerecord.errors.models.facility.attributes.image_file_dimension'))
     end
   end

--- a/app/uploaders/facility_image_uploader.rb
+++ b/app/uploaders/facility_image_uploader.rb
@@ -18,9 +18,9 @@ class FacilityImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
-    %w(png)
-  end
+  # def extension_whitelist
+  #   %w(png)
+  # end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/admin/facilities/_form.html.erb
+++ b/app/views/admin/facilities/_form.html.erb
@@ -8,8 +8,8 @@
       <%= f.input :image %>
     <% end %>
     <%= f.input :image_file, as: :file, hint: I18n.t('simple_form.hints.facility.image_file') %>
-    <%- if @facility.image.present? %>
-      <%= image_tag @facility.image_file.url, title: @facility.image_description %>
+    <%- if @facility.image_file.present? %>
+      <%= image_tag @facility.reload.image_file.url, title: @facility.image_description %>
     <% end %>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,11 +51,13 @@ en:
       models:
         facility:
           attributes:
-            image_file_dimension: Image dimensions have to be 50x50px aa
+            image_file_dimension: Image dimensions have to be 50x50px.
+            image_file_blank: You must select an icon image.
+            image_file_extension: The image must be in the PNG file type.
 
   simple_form:
     hints:
       court:
-        image_file: This photo will be forced to fit 350x275 pixels
+        image_file: This photo will be forced to fit 350x275 pixels.
       facility:
-        image_file: Only png with dimensions of 50x50px is allowed
+        image_file: The image must be 50x50 pixels in size and the PNG file type.

--- a/spec/features/admin/managing_facilities_spec.rb
+++ b/spec/features/admin/managing_facilities_spec.rb
@@ -13,7 +13,7 @@ feature 'As an admin I should be able to manage facility' do
 
     expect(page).to have_content('New facility_type')
     expect(page).not_to have_xpath('.//input[@id="facility_image"]')
-    expect(page).to have_content('Only png with dimensions of 50x50px is allowed')
+    expect(page).to have_content('The image must be 50x50 pixels in size and the PNG file type')
 
     fill_in('Name', with: 'Baby')
     fill_in('Image description', with: 'Baby change')

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Facility do
-  it { should validate_presence_of(:image_file) }
+  it { should validate_presence_of(:image_file).with_message('You must select an icon image.') }
 
   describe 'dimension validation' do
     let(:facility) { build(:facility, name: 'baby', image_file: image_file) }


### PR DESCRIPTION
- Removing image type validation from uploader because it was overwritten by AR validation.
- Updating validation messages
- An image was hidden on edit form when a name was empty.

https://triadmoj.atlassian.net/browse/RST-111