### PR TITLE
Customizing error message for long explanation text

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -15,10 +15,11 @@
 class Contact < ActiveRecord::Base
   belongs_to :court
   belongs_to :contact_type
-  attr_accessible :in_leaflet, :name, :sort, :telephone, :contact_type_id, :explanation
+  alias_attribute :number_explanation, :explanation
+  attr_accessible :in_leaflet, :name, :sort, :telephone, :contact_type_id, :explanation, :number_explanation
 
   validates :telephone, presence:true, contact: true
-  validates_length_of :explanation, maximum: 85
+  validate :explanation_length
 
   has_paper_trail ignore: [:created_at, :updated_at], meta: {ip: :ip}
 
@@ -28,5 +29,12 @@ class Contact < ActiveRecord::Base
 
   def contact_type_name
     self.contact_type.name.blank? ? "another service" : self.contact_type.name
+  end
+
+  private
+  def explanation_length
+    if explanation && explanation.size > 85
+      errors.add(:number_explanation, I18n.t('activerecord.errors.models.contact.attributes.explanation.too_long', size: explanation.size))
+    end
   end
 end

--- a/app/views/admin/courts/_contact_fields.html.erb
+++ b/app/views/admin/courts/_contact_fields.html.erb
@@ -5,7 +5,7 @@
   </div>
   <fieldset id="contact-element">
     <%= f.association :contact_type, :include_blank => false %>
-    <%= f.input :explanation %>
+    <%= f.input :number_explanation %>
     <%= f.input :telephone %>
     <%= f.input :in_leaflet, :label => 'Show this contact in print out' %>
     <%= f.input :sort %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
       contact:
         contact_type: Service type
         telephone: Number
+        number_explanation: Explanation
       email:
         contact_type: Service type
       opening_time:
@@ -54,6 +55,10 @@ en:
             image_file_dimension: Image dimensions have to be 50x50px.
             image_file_blank: You must select an icon image.
             image_file_extension: The image must be in the PNG file type.
+        contact:
+          attributes:
+            explanation:
+              too_long: is too long (contains %{size} characters and maximum is 85 characters)
 
   simple_form:
     hints:

--- a/spec/features/admin/manage_court_contact_number_explanation_spec.rb
+++ b/spec/features/admin/manage_court_contact_number_explanation_spec.rb
@@ -8,14 +8,15 @@ feature 'Court Contact Explanation' do
   context 'admin' do
     let!(:court) { create(:court, name: 'the-court') }
     let!(:user) { create(:user) }
-
+    let(:long_explanation) do
+      'Enquiries Explanation which is very very very very very long message and even loooongeeeer'
+    end
     before do
       visit '/admin'
       sign_in user
     end
 
     scenario 'edit a court and verify the change', js: true do
-
       visit '/admin/courts/the-court/edit'
       expect(page).to have_content('Editing court')
       click_link 'Contact Numbers'
@@ -36,6 +37,23 @@ feature 'Court Contact Explanation' do
       click_link 'Contact Numbers'
       expect(page.body).to have_content('01443 408181')
       expect(page.body).to have_content('Enquiries Explanation')
+    end
+
+    scenario 'validating explanation message', js: true do
+      visit '/admin/courts/the-court/edit'
+      expect(page).to have_content('Editing court')
+      click_link 'Contact Numbers'
+      click_link 'Add contact information'
+
+      within_fieldset('contact-element') do
+        select 'Enquiries', from: 'Service type'
+        fill_in 'Number', with: '01443 408181'
+        fill_in 'Explanation', with: long_explanation
+      end
+
+      click_button 'Update'
+      expect(page).not_to have_content('Court was successfully updated')
+      expect(page).to have_content('Contacts number explanation is too long (contains 90 characters and maximum is 85 characters)')
     end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -9,6 +9,6 @@ describe Contact, type: :model do
     86.times { text += "s" }
     contact.explanation = text
     expect(contact.save).to be_falsey
-    expect(contact.errors.messages).to eql(explanation: ['is too long (maximum is 85 characters)'])
+    expect(contact.errors.messages).to eql(number_explanation: ['is too long (contains 86 characters and maximum is 85 characters)'])
   end
 end


### PR DESCRIPTION
I had to add an alias for the attribute so the error message is displayed with name phone explanation, not just explanation. I didn’t want to rename the DB column because it’s not necessary to do just for an error message. 