### PR TITLE
Adding civil partnership as a sub type for family.

### DIFF
--- a/app/controllers/admin/courts_controller.rb
+++ b/app/controllers/admin/courts_controller.rb
@@ -110,7 +110,7 @@ class Admin::CourtsController < Admin::ApplicationController
   end
 
   def family
-    @courts = Court.by_area_of_law([AreaOfLaw::Name::CHILDREN, AreaOfLaw::Name::DIVORCE, AreaOfLaw::Name::ADOPTION]).by_name.paginate(page: params[:page], per_page: 30)
+    @courts = Court.by_area_of_law([AreaOfLaw::Name::CHILDREN, AreaOfLaw::Name::DIVORCE, AreaOfLaw::Name::ADOPTION, AreaOfLaw::Name::CIVIL_PARTNERSHIP]).by_name.paginate(page: params[:page], per_page: 30)
     @area_of_law = AreaOfLaw.where(id: params[:area_of_law_id]).first || AreaOfLaw.where(name: AreaOfLaw::Name::CHILDREN).first
   end
 

--- a/app/helpers/courts_helper.rb
+++ b/app/helpers/courts_helper.rb
@@ -19,8 +19,9 @@ module CourtsHelper
   end
 
   def family_areas_of_law(&block)
-    AreaOfLaw.where(name: [AreaOfLaw::Name::CHILDREN, AreaOfLaw::Name::DIVORCE, AreaOfLaw::Name::ADOPTION]).each do |area|
-      block.call area.name, area.id
+    AreaOfLaw.where(name: [AreaOfLaw::Name::CHILDREN, AreaOfLaw::Name::DIVORCE,
+      AreaOfLaw::Name::ADOPTION, AreaOfLaw::Name::CIVIL_PARTNERSHIP]).each do |area|
+        block.call area.name, area.id
     end
   end
 

--- a/app/models/area_of_law.rb
+++ b/app/models/area_of_law.rb
@@ -32,6 +32,7 @@ class AreaOfLaw < ActiveRecord::Base
     DIVORCE            = 'Divorce'
     HOUSING_POSSESSION = 'Housing possession'
     MONEY_CLAIMS       = 'Money claims'
+    CIVIL_PARTNERSHIP  = 'Civil partnership'
   end
 
   class << self
@@ -41,7 +42,8 @@ class AreaOfLaw < ActiveRecord::Base
       children:           Name::CHILDREN,
       divorce:            Name::DIVORCE,
       housing_possession: Name::HOUSING_POSSESSION,
-      money_claims:       Name::MONEY_CLAIMS
+      money_claims:       Name::MONEY_CLAIMS,
+      civil_partnership:  Name::CIVIL_PARTNERSHIP
     }.each do |method_name, area_of_law_name|
       define_method method_name do
         find_by_name! area_of_law_name
@@ -49,7 +51,7 @@ class AreaOfLaw < ActiveRecord::Base
     end
   end
 
-  attr_accessible :name, :old_id, :slug, :type_possession, :type_bankruptcy, :type_money_claims, :type_children, 
+  attr_accessible :name, :old_id, :slug, :type_possession, :type_bankruptcy, :type_money_claims, :type_children,
     :type_adoption, :type_divorce, :group_id, :external_link, :external_link_desc
   has_many :remits
   has_many :courts, through: :remits

--- a/app/models/concerns/court/local_authorities.rb
+++ b/app/models/concerns/court/local_authorities.rb
@@ -37,7 +37,7 @@ module Concerns
           remit.save!
         end
 
-        %i(children divorce adoption).each do |method_name|
+        %i(children divorce adoption civil_partnership).each do |method_name|
           define_method :"#{method_name}_local_authorities" do
             area_local_authorities AreaOfLaw.send(method_name)
           end

--- a/spec/controllers/admin/courts_controller_spec.rb
+++ b/spec/controllers/admin/courts_controller_spec.rb
@@ -155,7 +155,7 @@ describe Admin::CourtsController do
         expect( response.status ).to eq(200)
       end
     end
-    
+
     describe "a json request" do
       it "responds with json" do
         get :new, format: :json
@@ -172,7 +172,7 @@ describe Admin::CourtsController do
   describe "#show" do
     let(:court){ Court.create(name: 'My Court') }
 
-    it "finds the right court" do 
+    it "finds the right court" do
       expect(Court).to receive_message_chain(:friendly,:find).with(court.id.to_s).and_return(court)
       get :show, id: court.id
     end
@@ -193,7 +193,7 @@ describe Admin::CourtsController do
         expect( response.status ).to eq(200)
       end
     end
-    
+
     describe "a json request" do
       it "responds with json" do
         get :show, id: court.id, format: :json
@@ -210,7 +210,7 @@ describe Admin::CourtsController do
   describe "#edit" do
     let(:court){ Court.create(name: 'My Court') }
 
-    it "finds the right court" do 
+    it "finds the right court" do
       expect(Court).to receive_message_chain(:friendly, :find).with(court.id.to_s).and_return(court)
       get :edit, id: court.id
     end
@@ -238,7 +238,7 @@ describe Admin::CourtsController do
         expect( response.status ).to eq(200)
       end
     end
-  
+
   end
 
 describe "#areas_of_law" do
@@ -272,7 +272,7 @@ describe "#areas_of_law" do
 
   describe "#court_types" do
     let(:mock_courts_by_name){ double('courts by name', paginate: 'paginated courts by name') }
-    before{ 
+    before{
       Court.stub(:by_name).and_return(mock_courts_by_name)
       CourtType.stub(:order).and_return('all court types')
     }
@@ -314,7 +314,7 @@ describe "#areas_of_law" do
       family_area = AreaOfLaw.where(name: 'Children').first_or_initialize
       family_area.save
       get :family, { page: 1 }
-      expect(assigns(:courts)).to eq(Court.by_area_of_law(['Children','Divorce','Adoption']).by_name.paginate(page: 1, per_page: 30))
+      expect(assigns(:courts)).to eq(Court.by_area_of_law(['Children','Divorce','Adoption', 'Civil partnership']).by_name.paginate(page: 1, per_page: 30))
     end
 
     it 'assigns @area_of_law' do

--- a/spec/helpers/courts_helper_spec.rb
+++ b/spec/helpers/courts_helper_spec.rb
@@ -77,7 +77,7 @@ describe CourtsHelper do
       Town.should_receive(:select).with('towns.id, towns.name').and_return(towns)
       helper.towns_with_county_where_duplicates_exist
     end
-    
+
     describe "each returned town" do
 
       it "is mapped to a new TownDisambiguator" do
@@ -85,6 +85,15 @@ describe CourtsHelper do
         TownDisambiguator.should_receive( :new ).exactly(:once).ordered.with(town2).and_return('disambiguated town 2')
         expect( helper.towns_with_county_where_duplicates_exist ).to eq( ['disambiguated town 1', 'disambiguated town 2'] )
       end
+    end
+  end
+
+  describe 'family_areas_of_law' do
+    it "call selected areas of law" do
+      expect(AreaOfLaw).to receive(:where).
+        with(name: ['Children','Divorce','Adoption', 'Civil partnership']).
+        and_return []
+      family_areas_of_law { |area, id| }
     end
   end
 end

--- a/spec/models/area_of_law_spec.rb
+++ b/spec/models/area_of_law_spec.rb
@@ -42,7 +42,7 @@ describe AreaOfLaw do
       area = create(:area_of_law, name: 'Area of law slugged')
       area.name = 'Law Slugged'
       area.save!
-      
+
       expect(area.to_param).to eq('area-of-law-slugged')
       expect(AreaOfLaw.find('area-of-law-slugged')).to eq(area)
     end
@@ -64,8 +64,8 @@ describe AreaOfLaw do
 
   describe 'class methods for named records' do
     it 'finds the record with the right name' do
-      names = ['Adoption', 'Bankruptcy', 'Children', 'Divorce', 'Housing possession', 'Money claims']
-      adoption, bankruptcy, children, divorce, housing_possession, money_claims =
+      names = ['Adoption', 'Bankruptcy', 'Children', 'Divorce', 'Housing possession', 'Money claims', 'Civil partnership']
+      adoption, bankruptcy, children, divorce, housing_possession, money_claims, civil_partnership =
         names.map { |name| create :area_of_law, name: name }
 
       expect(AreaOfLaw.adoption).to eq adoption
@@ -74,6 +74,7 @@ describe AreaOfLaw do
       expect(AreaOfLaw.divorce).to eq divorce
       expect(AreaOfLaw.housing_possession).to eq housing_possession
       expect(AreaOfLaw.money_claims).to eq money_claims
+      expect(AreaOfLaw.civil_partnership).to eq civil_partnership
     end
   end
 end


### PR DESCRIPTION
https://triadmoj.atlassian.net/browse/RST-163

We need to understand the implications of adding Civil Partnership here: Will admin and the data sync automatically handle data for Civil Partnership in the same way as Divorce, and allow local authority mapping for courts to be stored and transferred? To be tested after json file digest.