### PR TITLE
RST-892 upgrade vulnerable gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem 'guard'
   gem 'guard-livereload'
   gem 'letter_opener'
-  gem 'rubocop', require: false
+  gem 'rubocop', '0.49.1', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,15 +363,15 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
     netrc (0.11.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -624,4 +624,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     appsignal (2.3.2)
       rack
     arel (6.0.4)
-    ast (2.3.0)
+    ast (2.4.0)
     awesome_print (1.8.0)
     bcrypt (3.1.11)
     better_errors (2.3.0)
@@ -379,9 +379,9 @@ GEM
     paper_trail (3.0.9)
       activerecord (>= 3.0, < 5.0)
       activesupport (>= 3.0, < 5.0)
-    parallel (1.12.0)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    parallel (1.12.1)
+    parser (2.5.0.1)
+      ast (~> 2.4.0)
     pg (0.21.0)
     poltergeist (1.16.0)
       capybara (~> 2.1)
@@ -429,7 +429,7 @@ GEM
     rainbow (2.2.2)
       rake
     raindrops (0.19.0)
-    rake (12.0.0)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -477,7 +477,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
@@ -607,7 +607,7 @@ DEPENDENCIES
   rmagick
   rspec-collection_matchers
   rspec-rails (~> 3.6.1)
-  rubocop
+  rubocop (= 0.49.1)
   sass-rails (~> 4.0.5)
   sentry-raven
   shoulda-matchers (~> 3.1)


### PR DESCRIPTION
This PR will upgrade Nokogiri and Rubocop gems to patched versions. The scope of this task is not to upgrade the gems to their latest versions.

Rubocop v0.49.1 is the latest version that includes the patch for the `/tmp` vulnerability without the need to update any code stylings in the codebase.